### PR TITLE
[feature] Frontend for vision fine tuning

### DIFF
--- a/src/app/api/datasets/hf/preview/route.ts
+++ b/src/app/api/datasets/hf/preview/route.ts
@@ -1,6 +1,16 @@
 import { NextResponse } from "next/server";
 import { HF_TOKEN } from "../../../env";
 
+async function fetchAsBase64(url: string) {
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(`Failed to fetch image: ${response.statusText}`);
+	}
+	const buffer = await response.arrayBuffer();
+	const contentType = response.headers.get("content-type") || "image/jpeg";
+	return `data:${contentType};base64,${Buffer.from(buffer).toString("base64")}`;
+}
+
 export async function POST(request: Request) {
 	try {
 		const { dataset_id, config, split } = await request.json();
@@ -30,6 +40,28 @@ export async function POST(request: Request) {
 
 		// Get only the first 5 rows
 		const top5Rows = data.rows.slice(0, 5);
+
+		// Process rows to fetch and convert images to base64
+		for (const row of top5Rows) {
+			for (const key in row.row) {
+				if (
+					row.row[key] &&
+					typeof row.row[key] === "object" &&
+					row.row[key].src
+				) {
+					try {
+						// fetch the image here and return base64 to avoid link expiration
+						row.row[key].src = await fetchAsBase64(
+							row.row[key].src,
+						);
+					} catch (e) {
+						console.error(`Failed to fetch image for ${key}:`, e);
+						// Optionally, you can remove the image or set a placeholder
+						row.row[key] = { error: "Failed to load image" };
+					}
+				}
+			}
+		}
 
 		const columns = [];
 		for (const feature of data.features) {

--- a/src/app/api/inference/batch/route.ts
+++ b/src/app/api/inference/batch/route.ts
@@ -4,20 +4,20 @@ import { HF_TOKEN, INFERENCE_SERVICE_URL } from "../../env";
 export async function POST(request: Request) {
 	try {
 		const body = await request.json();
-		const { job_id_or_repo_id, prompts, storage_type } = body;
+		const { job_id_or_repo_id, messages, storage_type } = body;
 
 		// Prefill hf_token from env if not provided
 		const hf_token = body.hf_token || HF_TOKEN;
 		if (
 			!job_id_or_repo_id ||
-			!Array.isArray(prompts) ||
-			prompts.length === 0 ||
+			!Array.isArray(messages) ||
+			messages.length === 0 ||
 			!storage_type ||
 			!hf_token
 		) {
 			return NextResponse.json(
 				{
-					error: "job_id_or_repo_id, prompts (array), storage_type, and hf_token are required",
+					error: "job_id_or_repo_id, messages (array), storage_type, and hf_token are required",
 				},
 				{ status: 400 },
 			);
@@ -28,7 +28,7 @@ export async function POST(request: Request) {
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({
 				job_id_or_repo_id,
-				prompts,
+				messages,
 				storage_type,
 				hf_token,
 			}),

--- a/src/app/dashboard/datasets/configuration/page.tsx
+++ b/src/app/dashboard/datasets/configuration/page.tsx
@@ -32,6 +32,8 @@ import {
 	userMessageMappingAtom,
 	userMessageTabAtom,
 	userMessageTemplateAtom,
+	visionEnabledAtom,
+	visionFieldMappingAtom,
 } from "@/atoms";
 import DatasetPreview from "@/components/dataset-preview";
 import FieldMapping from "@/components/field-mapping";
@@ -61,6 +63,7 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
+import VisionFieldMapping from "@/components/vision-field-mapping";
 import { cn } from "@/lib/utils";
 import { useAtom, useAtomValue } from "jotai";
 import { Loader2 } from "lucide-react";
@@ -113,6 +116,12 @@ const DatasetConfiguration = () => {
 	);
 	const [assistantMessageMapping, setAssistantMessageMapping] = useAtom(
 		assistantMessageMappingAtom,
+	);
+
+	// Vision Field Mapping
+	const [visionEnabled, setVisionEnabled] = useAtom(visionEnabledAtom);
+	const [visionFieldMapping, setVisionFieldMapping] = useAtom(
+		visionFieldMappingAtom,
 	);
 
 	// Split Settings
@@ -398,7 +407,9 @@ const DatasetConfiguration = () => {
 									? assistantMessageTemplate
 									: assistantMessageColumn,
 						},
+						...visionFieldMapping,
 					},
+					vision_enabled: visionEnabled,
 					normalize_whitespace: true,
 					split_config: splitConfig,
 					augmentation_config: augmentationConfig,
@@ -436,6 +447,7 @@ const DatasetConfiguration = () => {
 					numExamples: data.num_examples,
 					createdAt: data.created_at,
 					splits: data.splits,
+					modality: data.modality || "text", // Default to text if not provided
 				};
 
 				// Add the new dataset to the existing list
@@ -551,6 +563,51 @@ const DatasetConfiguration = () => {
 						forMessage="assistant"
 					/>
 				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader className="border-b border-input">
+					<CardTitle>Vision Settings</CardTitle>
+					<CardDescription>
+						Configure the vision settings for the dataset.
+					</CardDescription>
+				</CardHeader>
+				<CardContent
+					className={cn(
+						"border-input",
+						visionEnabled && "border-b",
+						!visionEnabled && "border-b-0",
+					)}
+				>
+					<div className="flex items-center space-x-2">
+						<Checkbox
+							id="vision-enabled"
+							checked={visionEnabled}
+							onCheckedChange={checked =>
+								setVisionEnabled(checked as boolean)
+							}
+						/>
+						<Label htmlFor="vision-enabled">Enable Vision</Label>
+					</div>
+					<p className="text-sm text-muted-foreground mt-2">
+						Enable this to apply vision settings to your dataset.
+					</p>
+				</CardContent>
+				{visionEnabled && (
+					<CardContent className="border-b-0">
+						<h2 className="font-semibold mb-2">
+							Image Field Mapping
+						</h2>
+						<p className="text-sm text-muted-foreground mb-4">
+							Map the image fields with the dataset columns.
+						</p>
+						<VisionFieldMapping
+							columns={datasetSelection.columns}
+							value={visionFieldMapping}
+							onChange={setVisionFieldMapping}
+						/>
+					</CardContent>
+				)}
 			</Card>
 
 			<Card>

--- a/src/app/dashboard/datasets/page.tsx
+++ b/src/app/dashboard/datasets/page.tsx
@@ -29,6 +29,7 @@ const Datasets = () => {
 						num_examples: number;
 						created_at: string;
 						splits: string[];
+						modality: "text" | "vision";
 					}) => ({
 						datasetName: dataset.dataset_name,
 						datasetId: dataset.dataset_id,
@@ -40,6 +41,7 @@ const Datasets = () => {
 						numExamples: dataset.num_examples,
 						createdAt: dataset.created_at,
 						splits: dataset.splits,
+						modality: dataset.modality,
 					}),
 				);
 				setDatasets(formattedData);

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -38,6 +38,7 @@ const DatasetsSection = () => {
 				const response = await fetch("/api/datasets");
 				const data = await response.json();
 
+				// We need to map from the API response to our DatasetSample type
 				const formattedData = data.datasets.map(
 					(dataset: {
 						dataset_name: string;
@@ -47,6 +48,7 @@ const DatasetsSection = () => {
 						num_examples: number;
 						created_at: string;
 						splits: string[];
+						modality: "text" | "vision";
 					}) => ({
 						datasetName: dataset.dataset_name,
 						datasetId: dataset.dataset_id,
@@ -58,6 +60,7 @@ const DatasetsSection = () => {
 						numExamples: dataset.num_examples,
 						createdAt: dataset.created_at,
 						splits: dataset.splits,
+						modality: dataset.modality,
 					}),
 				);
 				setDatasets(formattedData);

--- a/src/app/dashboard/training/[jobId]/page.tsx
+++ b/src/app/dashboard/training/[jobId]/page.tsx
@@ -211,7 +211,6 @@ export default function JobDetailPage() {
 				</div>
 			</div>
 			<Card className="p-6">
-				<h2 className="text-xl font-semibold mb-4">Job Details</h2>
 				<div className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-2 mb-2">
 					<div className="text-muted-foreground">Job ID</div>
 					<div className="break-all">{jobId}</div>

--- a/src/app/dashboard/training/new/dataset/page.tsx
+++ b/src/app/dashboard/training/new/dataset/page.tsx
@@ -1,17 +1,23 @@
 "use client";
 
-import { trainingDatasetIdAtom, trainingModelAtom } from "@/atoms";
+import {
+	trainingDatasetIdAtom,
+	trainingDatasetModalityAtom,
+	trainingModelAtom,
+} from "@/atoms";
 import { datasetsAtom, datasetsLoadingAtom } from "@/atoms";
 import { Button } from "@/components/ui/button";
 import { CardDescription } from "@/components/ui/card";
 import { RadioCardGroup, RadioCardGroupItem } from "@/components/ui/radio-card";
 import { useAtom } from "jotai";
+import { FileTextIcon, ImageIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { toast } from "sonner";
 
 export default function DatasetSelectionPage() {
 	const [datasetId, setDatasetId] = useAtom(trainingDatasetIdAtom);
+	const [_, setModality] = useAtom(trainingDatasetModalityAtom);
 	const [model] = useAtom(trainingModelAtom);
 	const [datasets] = useAtom(datasetsAtom);
 	const [isLoading] = useAtom(datasetsLoadingAtom);
@@ -47,7 +53,15 @@ export default function DatasetSelectionPage() {
 			) : (
 				<RadioCardGroup
 					className="grid grid-cols-1 md:grid-cols-2 gap-4"
-					onValueChange={value => setDatasetId(value as string)}
+					onValueChange={value => {
+						const id = value as string;
+						setDatasetId(id);
+						// update modality based on selected dataset
+						const selected = datasets.find(
+							ds => ds.datasetName === id,
+						);
+						setModality(selected?.modality ?? null);
+					}}
 				>
 					{datasets.map(ds => (
 						<RadioCardGroupItem
@@ -55,8 +69,13 @@ export default function DatasetSelectionPage() {
 							value={ds.datasetName}
 							checked={datasetId === ds.datasetName}
 						>
-							<div className="font-semibold mb-8">
+							<div className="flex items-center gap-2 font-semibold mb-8">
 								{ds.datasetName}
+								{ds.modality === "vision" ? (
+									<ImageIcon className="w-4 h-4" />
+								) : (
+									<FileTextIcon className="w-4 h-4" />
+								)}
 							</div>
 							<div className="text-xs text-muted-foreground mb-1">
 								Hugging Face ID:{" "}

--- a/src/app/dashboard/training/new/review/page.tsx
+++ b/src/app/dashboard/training/new/review/page.tsx
@@ -3,6 +3,7 @@
 import {
 	trainingConfigAtom,
 	trainingDatasetIdAtom,
+	trainingDatasetModalityAtom,
 	trainingJobNameAtom,
 	trainingModelAtom,
 } from "@/atoms";
@@ -25,6 +26,7 @@ import { toast } from "sonner";
 export default function TrainingReviewPage() {
 	const [model] = useAtom(trainingModelAtom);
 	const [datasetId] = useAtom(trainingDatasetIdAtom);
+	const [modality] = useAtom(trainingDatasetModalityAtom);
 	const [config] = useAtom(trainingConfigAtom);
 	const [jobName] = useAtom(trainingJobNameAtom);
 	const router = useRouter();
@@ -77,6 +79,8 @@ export default function TrainingReviewPage() {
 					api_key: config.wandb_api_key,
 					project: config.wandb_project,
 				},
+				// modality is not one of the config because it should not be changed by the user
+				modality: modality || "text",
 			};
 			const res = await fetch("/api/jobs", {
 				method: "POST",
@@ -139,6 +143,11 @@ export default function TrainingReviewPage() {
 						label: "Job Name",
 						value: jobName || "-",
 						editLink: "/dashboard/training/new/configuration",
+					})}
+					{SummaryRow({
+						label: "Modality",
+						value: modality || "text",
+						editLink: "",
 					})}
 					{SummaryRow({
 						label: "Dataset",

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -137,6 +137,7 @@ export type TrainingModelType = {
 };
 export const trainingModelAtom = atom<TrainingModelType | null>(null);
 export const trainingDatasetIdAtom = atom<string>("");
+export const trainingDatasetModalityAtom = atom<"text" | "vision" | null>(null);
 export type TrainingConfigType = {
 	method: string;
 	lora_rank: number;

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -1,4 +1,5 @@
 import { atom } from "jotai";
+import type { FieldMappings } from "./types/dataset";
 
 /* ********** Datasets Atoms ********** */
 export type DatasetSample = {
@@ -9,6 +10,7 @@ export type DatasetSample = {
 	numExamples: number;
 	createdAt: string;
 	splits: string[];
+	modality: "text" | "vision";
 };
 export const datasetsAtom = atom<DatasetSample[]>([]);
 export const datasetsLoadingAtom = atom<boolean>(false);
@@ -33,7 +35,7 @@ export const hfDatasetPreviewLoadingAtom = atom(false);
 export const hfDatasetColumnsAtom = atom<string[]>([]);
 
 export type DatasetPreviewRow = {
-	row: Record<string, string>;
+	row: Record<string, unknown>;
 };
 export const hfDatasetPreviewRowsAtom = atom<DatasetPreviewRow[]>([]);
 
@@ -54,6 +56,7 @@ export type DatasetSelectionType = {
 	config?: string;
 	rows: DatasetPreviewRow[];
 	columns: string[];
+	modality?: "text" | "vision";
 };
 export const datasetSelectionAtom = atom<DatasetSelectionType | null>(null);
 /* ********** Dataset Selection Atoms ********** */
@@ -95,6 +98,10 @@ export const assistantMessageMappingAtom = atom<FieldMapping>({
 	type: "column",
 	value: "",
 });
+
+// Vision Field Mapping
+export const visionEnabledAtom = atom<boolean>(false);
+export const visionFieldMappingAtom = atom<FieldMappings>({});
 
 // Split Settings
 export const splitTypeAtom = atom<"hf_split" | "manual_split" | "no_split">(

--- a/src/components/batch-inference-form.tsx
+++ b/src/components/batch-inference-form.tsx
@@ -7,6 +7,7 @@ import type {
 } from "@/types/dataset";
 import type { BatchInferenceResult, TrainingJob } from "@/types/training";
 import { Loader2 } from "lucide-react";
+import Image from "next/image";
 import { useState } from "react";
 
 interface BatchInferenceFormProps {
@@ -161,13 +162,84 @@ export default function BatchInferenceForm({
 											);
 									}}
 								/>
-								<pre className="text-xs whitespace-pre-wrap max-h-36 overflow-auto flex-1">
-									{JSON.stringify(
-										getInferenceMessages(sample.messages),
-										null,
-										2,
+								<div className="flex-1 space-y-1 text-sm">
+									{getInferenceMessages(sample.messages).map(
+										msg => {
+											const contentKey =
+												typeof msg.content === "string"
+													? msg.content.slice(0, 20)
+													: msg.content
+															.map(part =>
+																part.type ===
+																"text"
+																	? part.text.slice(
+																			0,
+																			20,
+																		)
+																	: part.image.slice(
+																			0,
+																			20,
+																		),
+															)
+															.join("-");
+											return (
+												<div
+													key={`${msg.role}-${contentKey}`}
+													className="space-y-1"
+												>
+													{typeof msg.content ===
+													"string" ? (
+														<p>
+															<b>{msg.role}:</b>{" "}
+															{msg.content}
+														</p>
+													) : (
+														<div className="flex flex-col gap-2">
+															{msg.content.map(
+																part =>
+																	part.type ===
+																	"text" ? (
+																		<p
+																			key={
+																				part.text
+																			}
+																		>
+																			<b>
+																				{
+																					msg.role
+																				}
+																				:
+																			</b>{" "}
+																			{
+																				part.text
+																			}
+																		</p>
+																	) : (
+																		<Image
+																			key={
+																				part.image
+																			}
+																			src={
+																				part.image
+																			}
+																			alt=""
+																			width={
+																				200
+																			}
+																			height={
+																				200
+																			}
+																			className="rounded-md"
+																		/>
+																	),
+															)}
+														</div>
+													)}
+												</div>
+											);
+										},
 									)}
-								</pre>
+								</div>
 							</label>
 						))}
 					</div>

--- a/src/components/dataset-card.tsx
+++ b/src/components/dataset-card.tsx
@@ -1,4 +1,5 @@
 import type { DatasetSample } from "@/atoms";
+import { FileTextIcon, ImageIcon } from "lucide-react";
 import Link from "next/link";
 import {
 	Card,
@@ -9,11 +10,18 @@ import {
 } from "./ui/card";
 
 const DatasetCard = ({ dataset }: { dataset: DatasetSample }) => {
+	const ModalityIcon =
+		dataset.modality === "vision" ? ImageIcon : FileTextIcon;
 	return (
 		<Link href={`/dashboard/datasets/${dataset.datasetName}`}>
 			<Card className="hover:bg-muted/30 transition-colors duration-200">
 				<CardHeader>
-					<CardTitle>{dataset.datasetName}</CardTitle>
+					<CardTitle className="flex items-center gap-2">
+						{dataset.datasetName}
+						{dataset.modality && (
+							<ModalityIcon className="w-4 h-4" />
+						)}
+					</CardTitle>
 					<CardDescription>
 						{new Date(dataset.createdAt).toLocaleString()}
 					</CardDescription>

--- a/src/components/dataset-preview.tsx
+++ b/src/components/dataset-preview.tsx
@@ -14,12 +14,11 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table";
+import Image from "next/image";
 
 const DatasetPreview = ({
 	rows,
-}: {
-	rows: { row: Record<string, string> }[];
-}) => {
+}: { rows: { row: Record<string, unknown> }[] }) => {
 	return (
 		<Card>
 			<CardHeader>
@@ -56,15 +55,30 @@ const DatasetPreview = ({
 									<TableRow key={key}>
 										{Object.keys(rowObj.row).map(col => {
 											const value = rowObj.row[col];
+											const isImage =
+												typeof value === "object" &&
+												value !== null &&
+												"src" in value;
 											return (
 												<TableCell key={col}>
-													<span
-														className={
-															"truncate max-w-[300px] inline-block align-bottom"
-														}
-													>
-														{value}
-													</span>
+													{isImage ? (
+														<Image
+															src={value.src}
+															alt={col}
+															width={value.width}
+															height={
+																value.height
+															}
+														/>
+													) : (
+														<span
+															className={
+																"truncate max-w-[300px] inline-block align-bottom"
+															}
+														>
+															{value}
+														</span>
+													)}
 												</TableCell>
 											);
 										})}

--- a/src/components/dataset-preview.tsx
+++ b/src/components/dataset-preview.tsx
@@ -46,15 +46,12 @@ const DatasetPreview = ({
 							</TableRow>
 						</TableHeader>
 						<TableBody className="rounded-md">
-							{rows.map((rowObj, i) => {
-								const key =
-									rowObj.row.question_id ||
-									rowObj.row.plot_id ||
-									i;
-								return (
-									<TableRow key={key}>
-										{Object.keys(rowObj.row).map(col => {
-											const value = rowObj.row[col];
+							{rows.map((rowObj, _) => (
+								<TableRow
+									key={`row-${JSON.stringify(rowObj.row)}`}
+								>
+									{Object.entries(rowObj.row).map(
+										([col, value]) => {
 											const isImage =
 												typeof value === "object" &&
 												value !== null &&
@@ -63,28 +60,29 @@ const DatasetPreview = ({
 												<TableCell key={col}>
 													{isImage ? (
 														<Image
-															src={value.src}
-															alt={col}
-															width={value.width}
-															height={
-																value.height
+															src={
+																(
+																	value as {
+																		src: string;
+																	}
+																).src
 															}
+															alt={col}
+															width={200}
+															height={200}
+															className="rounded-md"
 														/>
 													) : (
-														<span
-															className={
-																"truncate max-w-[300px] inline-block align-bottom"
-															}
-														>
-															{value}
+														<span className="truncate max-w-[300px] inline-block align-bottom">
+															{String(value)}
 														</span>
 													)}
 												</TableCell>
 											);
-										})}
-									</TableRow>
-								);
-							})}
+										},
+									)}
+								</TableRow>
+							))}
 						</TableBody>
 					</Table>
 				</div>

--- a/src/components/local-dataset-selector.tsx
+++ b/src/components/local-dataset-selector.tsx
@@ -142,6 +142,8 @@ const LocalDatasetSelector = () => {
 										num_examples: localDatasetSize,
 									},
 								],
+								// TODO: We do not support local uploaded vision datasets yet!!
+								modality: "text",
 							});
 
 							router.push("/dashboard/datasets/configuration");

--- a/src/components/training-job-card.tsx
+++ b/src/components/training-job-card.tsx
@@ -8,6 +8,8 @@ import {
 	CardTitle,
 } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+import type { TrainingJob } from "@/types/training";
+import { FileTextIcon, ImageIcon } from "lucide-react";
 import Link from "next/link";
 
 const statusColor: Record<string, string> = {
@@ -19,16 +21,13 @@ const statusColor: Record<string, string> = {
 };
 
 export type TrainingJobCardProps = {
-	job: {
-		job_id: string;
-		job_status?: string;
-		base_model_id?: string;
-		job_name?: string;
-	};
+	job: TrainingJob;
 };
 
 export default function TrainingJobCard({ job }: TrainingJobCardProps) {
-	const color = statusColor[job.job_status ?? "unknown"] ?? "bg-muted";
+	const color = statusColor[job.status ?? "unknown"] ?? "bg-muted";
+	const ModalityIcon = job.modality === "vision" ? ImageIcon : FileTextIcon;
+
 	return (
 		// This already has a link so do not wrap this in a Link component
 		<Link href={`/dashboard/training/${job.job_id}`}>
@@ -36,14 +35,15 @@ export default function TrainingJobCard({ job }: TrainingJobCardProps) {
 				<CardHeader>
 					<CardTitle className="flex items-center gap-2">
 						{job.job_name ?? job.job_id}
-						{job.job_status && (
+						{job.status && (
 							<span
 								className={cn("w-2 h-2 rounded-full", color)}
 							/>
 						)}
+						{job.modality && <ModalityIcon className="w-4 h-4" />}
 					</CardTitle>
 					<CardDescription className="capitalize">
-						Status: {job.job_status ?? "—"}
+						Status: {job.status ?? "—"}
 					</CardDescription>
 				</CardHeader>
 				<CardContent className="text-sm text-muted-foreground">

--- a/src/components/vision-field-mapping.tsx
+++ b/src/components/vision-field-mapping.tsx
@@ -1,0 +1,78 @@
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import type { FieldMappings } from "@/types/dataset";
+import { PlusIcon, TrashIcon } from "lucide-react";
+
+const VisionFieldMapping = ({
+	columns,
+	value,
+	onChange,
+}: {
+	columns: string[];
+	value: FieldMappings;
+	onChange: (value: FieldMappings) => void;
+}) => {
+	const handleAddMapping = () => {
+		const newKey = `image_field_${Object.keys(value).length + 1}`;
+		onChange({ ...value, [newKey]: { type: "image", value: "" } });
+	};
+
+	const handleRemoveMapping = (key: string) => {
+		const newValue = { ...value };
+		delete newValue[key];
+		onChange(newValue);
+	};
+
+	const handleColumnChange = (key: string, newColumn: string) => {
+		onChange({ ...value, [key]: { ...value[key], value: newColumn } });
+	};
+
+	return (
+		<div className="space-y-4">
+			{Object.entries(value).map(([key, mapping]) => (
+				<div key={key} className="flex items-end gap-2">
+					<div className="flex-grow space-y-2">
+						<Label htmlFor={key}>Image Column</Label>
+						<Select
+							value={mapping.value}
+							onValueChange={newColumn =>
+								handleColumnChange(key, newColumn)
+							}
+						>
+							<SelectTrigger id={key}>
+								<SelectValue placeholder="Select a column for the image" />
+							</SelectTrigger>
+							<SelectContent>
+								{columns.map(column => (
+									<SelectItem key={column} value={column}>
+										{column}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+					<Button
+						variant="destructive"
+						size="icon"
+						onClick={() => handleRemoveMapping(key)}
+					>
+						<TrashIcon className="h-4 w-4" />
+					</Button>
+				</div>
+			))}
+			<Button onClick={handleAddMapping} className="w-full">
+				<PlusIcon className="mr-2 h-4 w-4" />
+				Add Image Mapping
+			</Button>
+		</div>
+	);
+};
+
+export default VisionFieldMapping;

--- a/src/types/dataset.ts
+++ b/src/types/dataset.ts
@@ -32,6 +32,7 @@ export interface DatasetDetail {
 	dataset_source: "upload" | "huggingface";
 	dataset_id: string;
 	created_at: string;
+	modality: "text" | "vision";
 	splits: DatasetSplit[];
 }
 
@@ -39,4 +40,18 @@ export interface DatasetDetailState {
 	data: DatasetDetail | null;
 	loading: boolean;
 	error: string | null;
+}
+
+export interface FieldMapping {
+	type: "template" | "column" | "image";
+	value: string;
+}
+
+export interface FieldMappings {
+	[key: string]: FieldMapping;
+}
+
+export interface VisionConfig {
+	vision_enabled: boolean;
+	field_mappings: FieldMappings;
 }

--- a/src/types/dataset.ts
+++ b/src/types/dataset.ts
@@ -1,5 +1,17 @@
+export interface TextContentPart {
+	type: "text";
+	text: string;
+}
+
+export interface ImageContentPart {
+	type: "image";
+	image: string;
+}
+
+export type MessageContent = string | (TextContentPart | ImageContentPart)[];
+
 export interface DatasetMessage {
-	content: string;
+	content: MessageContent;
 	role: "system" | "user" | "assistant";
 }
 

--- a/src/types/training.ts
+++ b/src/types/training.ts
@@ -8,6 +8,7 @@ export interface TrainingJob {
 	wandb_url?: string;
 	adapter_path?: string;
 	error?: string;
+	modality?: "text" | "vision";
 }
 
 export interface BatchInferenceResult {


### PR DESCRIPTION
Implements all the proposed changes in #10 #13 

1. General image support for HF dataset preview, dataset samples (post preprocessing + general) preview, batch inference samples preview by using `Image` component and existing base64 images from backend
2. Vision field configuration in preprocessing settings page
3. Make batch inference work with images and sending in ChatML format
4. Handling the modality field for dataset and jobs and rendering icon for readability
5. Updating preprocess and train request to include `modality` field auto-detected and filled
6. Select split from which batch inference samples are drawn

**You can test frontend locally by running any preprocess and train, the dataset used for testing was `unsloth/LaTeX_OCR`**

> [!CAUTION]
> There is a known issue on the backend where batch inference endpoint does not support multiple vision samples, only select one for now for vision samples, this is not a frontend issue it will be fixed later on the backend