### PR TITLE
[feat] Integration Eval and Export with Frontend

### DIFF
--- a/src/app/api/datasets/[datasetName]/delete/route.ts
+++ b/src/app/api/datasets/[datasetName]/delete/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { PREPROCESS_SERVICE_URL } from "../../../env";
+
+export async function DELETE(
+	request: Request,
+	{ params }: { params: Promise<{ datasetName: string }> },
+) {
+	try {
+		const { datasetName } = await params;
+
+		// Call the backend preprocessing service
+		const backendUrl = `${PREPROCESS_SERVICE_URL}/datasets/${datasetName}/delete`;
+
+		const response = await fetch(backendUrl, {
+			method: "DELETE",
+		});
+		const data = await response.json();
+
+		if (!response.ok) {
+			return NextResponse.json(
+				{ error: data.error || "Failed to delete dataset" },
+				{ status: response.status },
+			);
+		}
+
+		return NextResponse.json(data);
+	} catch (error) {
+		console.error("Failed to delete dataset:", error);
+		return NextResponse.json(
+			{ error: "Could not delete dataset." },
+			{ status: 500 },
+		);
+	}
+}

--- a/src/app/api/evaluation/route.ts
+++ b/src/app/api/evaluation/route.ts
@@ -1,0 +1,67 @@
+import type { EvaluationRequest, EvaluationResponse } from "@/types/inference";
+import { HF_TOKEN, INFERENCE_SERVICE_URL } from "../env";
+
+export async function POST(request: Request) {
+	try {
+		const body = (await request.json()) as EvaluationRequest;
+
+		// Validate required fields
+		if (!body.adapter_path || !body.base_model_id || !body.dataset_id) {
+			return Response.json(
+				{
+					error: "adapter_path, base_model_id, and dataset_id are required",
+				},
+				{ status: 400 },
+			);
+		}
+
+		// Validate mutually exclusive options
+		if (body.task_type && body.metrics) {
+			return Response.json(
+				{ error: "task_type and metrics are mutually exclusive" },
+				{ status: 400 },
+			);
+		}
+
+		if (!body.task_type && !body.metrics) {
+			return Response.json(
+				{ error: "Either task_type or metrics must be specified" },
+				{ status: 400 },
+			);
+		}
+
+		const response = await fetch(`${INFERENCE_SERVICE_URL}/evaluation`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				hf_token: HF_TOKEN,
+				adapter_path: body.adapter_path,
+				base_model_id: body.base_model_id,
+				dataset_id: body.dataset_id,
+				...(body.task_type && { task_type: body.task_type }),
+				...(body.metrics && { metrics: body.metrics }),
+				...(body.max_samples && { max_samples: body.max_samples }),
+				num_sample_results: body.num_sample_results || 3,
+			}),
+		});
+
+		if (!response.ok) {
+			const errorText = await response.text();
+			return Response.json(
+				{ error: `Evaluation service error: ${errorText}` },
+				{ status: response.status },
+			);
+		}
+
+		const result = (await response.json()) as EvaluationResponse;
+		return Response.json(result);
+	} catch (error) {
+		console.error("Evaluation error:", error);
+		return Response.json(
+			{ error: "Internal server error" },
+			{ status: 500 },
+		);
+	}
+}

--- a/src/app/api/jobs/[jobId]/delete/route.ts
+++ b/src/app/api/jobs/[jobId]/delete/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
-import { TRAIN_SERVICE_URL } from "../../../../env";
+import { TRAIN_SERVICE_URL } from "../../../env";
 
-export async function GET(
+export async function DELETE(
 	request: Request,
 	{ params }: { params: Promise<{ jobId: string }> },
 ) {
@@ -9,23 +9,25 @@ export async function GET(
 		const { jobId } = await params;
 
 		// Call the backend training service
-		const backendUrl = `${TRAIN_SERVICE_URL}/jobs/${jobId}/download/gguf`;
+		const backendUrl = `${TRAIN_SERVICE_URL}/jobs/${jobId}/delete`;
 
-		const response = await fetch(backendUrl);
+		const response = await fetch(backendUrl, {
+			method: "DELETE",
+		});
 		const data = await response.json();
 
 		if (!response.ok) {
 			return NextResponse.json(
-				{ error: data.error || "Failed to get download URL" },
+				{ error: data.error || "Failed to delete job" },
 				{ status: response.status },
 			);
 		}
 
 		return NextResponse.json(data);
 	} catch (error) {
-		console.error("Failed to get GGUF download URL:", error);
+		console.error("Failed to delete job:", error);
 		return NextResponse.json(
-			{ error: "Could not get download link." },
+			{ error: "Could not delete job." },
 			{ status: 500 },
 		);
 	}

--- a/src/app/api/jobs/[jobId]/download/gguf/route.ts
+++ b/src/app/api/jobs/[jobId]/download/gguf/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { TRAIN_SERVICE_URL } from "../../../../env";
+
+export async function GET(
+	request: Request,
+	{ params }: { params: { jobId: string } },
+) {
+	try {
+		const { jobId } = params;
+
+		// Call the backend training service
+		const backendUrl = `${TRAIN_SERVICE_URL}/jobs/${jobId}/download/gguf`;
+
+		const response = await fetch(backendUrl);
+		const data = await response.json();
+
+		if (!response.ok) {
+			return NextResponse.json(
+				{ error: data.error || "Failed to get download URL" },
+				{ status: response.status },
+			);
+		}
+
+		return NextResponse.json(data);
+	} catch (error) {
+		console.error("Failed to get GGUF download URL:", error);
+		return NextResponse.json(
+			{ error: "Could not get download link." },
+			{ status: 500 },
+		);
+	}
+}

--- a/src/app/dashboard/training/[jobId]/batch/page.tsx
+++ b/src/app/dashboard/training/[jobId]/batch/page.tsx
@@ -63,7 +63,7 @@ export default function BatchInferencePage() {
 					Back
 				</Button>
 			</div>
-			<BatchInferenceForm job={job} jobId={jobId as string} />
+			<BatchInferenceForm job={job} />
 		</div>
 	);
 }

--- a/src/app/dashboard/training/[jobId]/evaluation/page.tsx
+++ b/src/app/dashboard/training/[jobId]/evaluation/page.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { jobCacheAtom } from "@/atoms";
+import EvaluationForm from "@/components/evaluation-form";
+import { Button } from "@/components/ui/button";
+import type { TrainingJob } from "@/types/training";
+import { useAtomValue } from "jotai";
+import { Loader2 } from "lucide-react";
+import { useParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+
+export default function EvaluationPage() {
+	const { jobId } = useParams<{ jobId: string }>();
+	const router = useRouter();
+	const cache = useAtomValue(jobCacheAtom);
+	const [job, setJob] = useState<TrainingJob | null>(
+		cache[jobId as string] ?? null,
+	);
+	const [loading, setLoading] = useState(!job);
+	const [error, setError] = useState<string | null>(null);
+
+	const fetchJob = useCallback(async () => {
+		setLoading(true);
+		setError(null);
+		try {
+			const res = await fetch(`/api/jobs/${jobId}`);
+			const data = await res.json();
+			if (!res.ok) throw new Error(data.error || "Failed to fetch job");
+			setJob(data);
+		} catch (err: unknown) {
+			setError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setLoading(false);
+		}
+	}, [jobId]);
+
+	useEffect(() => {
+		if (!job) {
+			fetchJob();
+		}
+	}, [fetchJob, job]);
+
+	if (loading)
+		return (
+			<div className="flex items-center justify-center py-20">
+				<Loader2 className="w-8 h-8 animate-spin" />
+			</div>
+		);
+	if (error) return <div className="p-8 text-red-600">Error: {error}</div>;
+	if (!job) return <div className="p-8">Job not found.</div>;
+	if (job.status !== "completed" || !job.adapter_path)
+		return (
+			<div className="p-8">
+				Model evaluation available only for completed jobs.
+			</div>
+		);
+
+	return (
+		<div className="max-w-5xl mx-auto py-8 space-y-6">
+			<div className="flex items-center justify-between">
+				<h1 className="text-2xl font-semibold">Model Evaluation</h1>
+				<Button variant="secondary" onClick={() => router.back()}>
+					Back
+				</Button>
+			</div>
+			<EvaluationForm job={job} />
+		</div>
+	);
+}

--- a/src/app/dashboard/training/[jobId]/page.tsx
+++ b/src/app/dashboard/training/[jobId]/page.tsx
@@ -359,6 +359,16 @@ export default function JobDetailPage() {
 									</p>
 								</div>
 							)}
+							{job.gguf_path && (
+								<div>
+									<span className="text-sm font-medium text-muted-foreground">
+										GGUF Path
+									</span>
+									<p className="text-sm font-mono bg-muted px-2 py-1 rounded mt-1 break-all">
+										{job.gguf_path}
+									</p>
+								</div>
+							)}
 							{job.wandb_url && (
 								<div>
 									<span className="text-sm font-medium text-muted-foreground">

--- a/src/app/dashboard/training/[jobId]/page.tsx
+++ b/src/app/dashboard/training/[jobId]/page.tsx
@@ -14,7 +14,8 @@ import {
 	SheetTitle,
 	SheetTrigger,
 } from "@/components/ui/sheet";
-import type { InferenceResult, TrainingJob } from "@/types/training";
+import type { InferenceResponse } from "@/types/inference";
+import type { TrainingJob } from "@/types/training";
 import { useAtomValue, useSetAtom } from "jotai";
 import { Loader2, RefreshCw } from "lucide-react";
 import Link from "next/link";
@@ -100,13 +101,12 @@ export default function JobDetailPage() {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
-					hf_token: "your_hf_token", // TODO: Get from user settings
 					adapter_path: job?.adapter_path,
 					base_model_id: job?.base_model_id,
 					prompt,
 				}),
 			});
-			const data = (await res.json()) as InferenceResult;
+			const data = (await res.json()) as InferenceResponse;
 			if (!res.ok) throw new Error("Inference failed");
 			setInferenceResult(data.result);
 		} catch (err: unknown) {
@@ -459,6 +459,14 @@ export default function JobDetailPage() {
 							>
 								<Button variant="outline" className="w-full">
 									Batch Inference
+								</Button>
+							</Link>
+							<Link
+								href={`/dashboard/training/${jobId}/evaluation`}
+								className="flex-1"
+							>
+								<Button variant="outline" className="w-full">
+									Evaluate Model
 								</Button>
 							</Link>
 						</div>

--- a/src/app/dashboard/training/[jobId]/page.tsx
+++ b/src/app/dashboard/training/[jobId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { jobCacheAtom } from "@/atoms";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import {
 	Sheet,
@@ -96,16 +96,14 @@ export default function JobDetailPage() {
 		setInferenceError(null);
 		setInferenceResult(null);
 		try {
-			const storageType = job?.adapter_path?.startsWith("gs://")
-				? "gcs"
-				: "hfhub";
 			const res = await fetch("/api/inference", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
-					job_id_or_repo_id: jobId,
+					hf_token: "your_hf_token", // TODO: Get from user settings
+					adapter_path: job?.adapter_path,
+					base_model_id: job?.base_model_id,
 					prompt,
-					storage_type: storageType,
 				}),
 			});
 			const data = (await res.json()) as InferenceResult;
@@ -131,78 +129,105 @@ export default function JobDetailPage() {
 	if (!job) return <div className="p-8">Job not found.</div>;
 
 	return (
-		<div className="max-w-2xl mx-auto py-8">
-			<div className="flex items-center justify-between mb-4">
-				<h2 className="text-xl font-semibold">Job Details</h2>
-				<div className="flex gap-2">
-					<button
-						type="button"
-						className="p-2 rounded hover:bg-muted transition-colors"
+		<div className="max-w-4xl mx-auto py-8 space-y-6">
+			{/* Header */}
+			<div className="flex items-center justify-between">
+				<div>
+					<h1 className="text-3xl font-bold tracking-tight">
+						Training Job
+					</h1>
+					<p className="text-muted-foreground mt-1">
+						Monitor and manage your training job
+					</p>
+				</div>
+				<div className="flex gap-3">
+					<Button
+						variant="outline"
+						size="sm"
 						onClick={() => fetchStatus(true)}
 						disabled={refreshing}
-						aria-label="Refresh job status"
+						className="flex items-center gap-2"
 					>
 						<RefreshCw
-							className={refreshing ? "animate-spin" : ""}
+							className={`w-4 h-4 ${refreshing ? "animate-spin" : ""}`}
 						/>
-					</button>
+						Refresh
+					</Button>
 					{job.status === "completed" && job.adapter_path && (
 						<Sheet
 							open={inferenceOpen}
 							onOpenChange={setInferenceOpen}
 						>
 							<SheetTrigger asChild>
-								<Button variant="outline">Try Inference</Button>
+								<Button
+									variant="outline"
+									size="sm"
+									className="flex items-center gap-2"
+								>
+									Try Inference
+								</Button>
 							</SheetTrigger>
-							<SheetContent side="right">
+							<SheetContent side="right" className="w-96">
 								<SheetHeader>
 									<SheetTitle>Try Inference</SheetTitle>
 									<SheetDescription>
-										Enter a prompt to run single inference
-										on this trained model.
+										Test your trained model with a custom
+										prompt
 									</SheetDescription>
 								</SheetHeader>
-								<div className="flex flex-col gap-4 p-4">
-									<label htmlFor="prompt">Prompt</label>
-									<Input
-										id="prompt"
-										value={prompt}
-										onChange={e =>
-											setPrompt(e.target.value)
-										}
-										placeholder="Enter your prompt here..."
-										disabled={inferenceLoading}
-									/>
+								<div className="flex flex-col gap-4 mt-6">
+									<div className="space-y-2">
+										<label
+											htmlFor="prompt"
+											className="text-sm font-medium"
+										>
+											Prompt
+										</label>
+										<Input
+											id="prompt"
+											value={prompt}
+											onChange={e =>
+												setPrompt(e.target.value)
+											}
+											placeholder="Enter your prompt here..."
+											disabled={inferenceLoading}
+										/>
+									</div>
 									<Button
 										onClick={handleInference}
 										disabled={
 											!prompt.trim() || inferenceLoading
 										}
+										className="w-full"
 									>
 										{inferenceLoading ? (
-											<Loader2 className="animate-spin w-4 h-4" />
+											<>
+												<Loader2 className="animate-spin w-4 h-4 mr-2" />
+												Running...
+											</>
 										) : (
 											"Run Inference"
 										)}
 									</Button>
 									{inferenceError && (
-										<div className="text-red-600 text-sm">
+										<div className="text-red-600 text-sm p-3 bg-red-50 rounded border">
 											{inferenceError}
 										</div>
 									)}
 									{inferenceResult && (
-										<div className="bg-muted p-3 rounded text-sm whitespace-pre-wrap">
-											<strong>Result:</strong>
-											<div>{inferenceResult}</div>
+										<div className="space-y-2">
+											<span className="text-sm font-medium">
+												Result:
+											</span>
+											<div className="bg-muted p-3 rounded text-sm whitespace-pre-wrap max-h-60 overflow-auto border">
+												{inferenceResult}
+											</div>
 										</div>
 									)}
-									{/* Single inference only. Batch inference is available as separate page. */}
 								</div>
-								<SheetFooter>
+								<SheetFooter className="mt-6">
 									<SheetClose asChild>
-										<Button variant="secondary">
-											Close
-										</Button>
+										<Button variant="outline">Close</Button>
 									</SheetClose>
 								</SheetFooter>
 							</SheetContent>
@@ -210,68 +235,236 @@ export default function JobDetailPage() {
 					)}
 				</div>
 			</div>
-			<Card className="p-6">
-				<div className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-2 mb-2">
-					<div className="text-muted-foreground">Job ID</div>
-					<div className="break-all">{jobId}</div>
-					<div className="text-muted-foreground">Status</div>
-					<div>{job.status}</div>
-					{job.base_model_id && (
-						<>
-							<div className="text-muted-foreground">
-								Base Model
-							</div>
-							<div>{job.base_model_id}</div>
-						</>
-					)}
-					{job.processed_dataset_id && (
-						<>
-							<div className="text-muted-foreground">
-								Processed Dataset ID
-							</div>
-							<div>{job.processed_dataset_id}</div>
-						</>
-					)}
-					{job.adapter_path && (
-						<>
-							<div className="text-muted-foreground">
-								Adapter Path
-							</div>
-							<div className="break-all">{job.adapter_path}</div>
-						</>
-					)}
-					{job.wandb_url && (
-						<>
-							<div className="text-muted-foreground">
-								WandB URL
-							</div>
-							<div>
-								<a
-									href={job.wandb_url}
-									target="_blank"
-									rel="noopener noreferrer"
-									className="text-blue-600 underline"
-								>
-									{job.wandb_url}
-								</a>
-							</div>
-						</>
-					)}
-					{job.error && (
-						<>
-							<div className="text-muted-foreground">Error</div>
-							<div className="text-red-600">{job.error}</div>
-						</>
-					)}
+
+			{/* Status Banner */}
+			<div
+				className={`p-4 rounded-lg border ${
+					job.status === "completed"
+						? "bg-green-50 border-green-200"
+						: job.status === "failed"
+							? "bg-red-50 border-red-200"
+							: job.status === "training"
+								? "bg-blue-50 border-blue-200"
+								: "bg-yellow-50 border-yellow-200"
+				}`}
+			>
+				<div className="flex items-center gap-3">
+					<div
+						className={`w-3 h-3 rounded-full ${
+							job.status === "completed"
+								? "bg-green-500"
+								: job.status === "failed"
+									? "bg-red-500"
+									: job.status === "training"
+										? "bg-blue-500 animate-pulse"
+										: "bg-yellow-500 animate-pulse"
+						}`}
+					/>
+					<div>
+						<p className="font-medium capitalize text-gray-900">
+							{job.status || "Unknown"}
+						</p>
+						<p className="text-sm text-muted-foreground">
+							{job.status === "completed" &&
+								"Training completed successfully"}
+							{job.status === "failed" && "Training failed"}
+							{job.status === "training" &&
+								"Training in progress..."}
+							{job.status === "preparing" &&
+								"Preparing training environment..."}
+							{job.status === "queued" &&
+								"Job queued for processing"}
+						</p>
+					</div>
 				</div>
-				{job.status === "completed" && job.adapter_path && (
-					<Link href={`/dashboard/training/${jobId}/batch`}>
-						<Button variant="outline" className="w-full">
-							Batch Inference
-						</Button>
-					</Link>
-				)}
-			</Card>
+			</div>
+
+			{/* Job Information Cards */}
+			<div className="grid md:grid-cols-2 gap-6">
+				{/* Basic Information */}
+				<Card>
+					<CardHeader>
+						<h3 className="text-lg font-semibold">
+							Job Information
+						</h3>
+					</CardHeader>
+					<CardContent className="space-y-4">
+						<div className="space-y-3">
+							<div>
+								<span className="text-sm font-medium text-muted-foreground">
+									Job ID
+								</span>
+								<p className="text-sm font-mono break-all bg-muted px-2 py-1 rounded mt-1">
+									{jobId}
+								</p>
+							</div>
+							{job.job_name && (
+								<div>
+									<span className="text-sm font-medium text-muted-foreground">
+										Job Name
+									</span>
+									<p className="mt-1">{job.job_name}</p>
+								</div>
+							)}
+							{job.modality && (
+								<div>
+									<span className="text-sm font-medium text-muted-foreground">
+										Modality
+									</span>
+									<p className="mt-1 capitalize">
+										{job.modality}
+									</p>
+								</div>
+							)}
+							{job.base_model_id && (
+								<div>
+									<span className="text-sm font-medium text-muted-foreground">
+										Base Model
+									</span>
+									<p className="text-sm font-mono bg-muted px-2 py-1 rounded mt-1">
+										{job.base_model_id}
+									</p>
+								</div>
+							)}
+							{job.processed_dataset_id && (
+								<div>
+									<span className="text-sm font-medium text-muted-foreground">
+										Dataset
+									</span>
+									<p className="text-sm font-mono bg-muted px-2 py-1 rounded mt-1">
+										{job.processed_dataset_id}
+									</p>
+								</div>
+							)}
+						</div>
+					</CardContent>
+				</Card>
+
+				{/* Output Information */}
+				<Card>
+					<CardHeader>
+						<h3 className="text-lg font-semibold">
+							Output & Resources
+						</h3>
+					</CardHeader>
+					<CardContent className="space-y-4">
+						<div className="space-y-3">
+							{job.adapter_path && (
+								<div>
+									<span className="text-sm font-medium text-muted-foreground">
+										Adapter Path
+									</span>
+									<p className="text-sm font-mono bg-muted px-2 py-1 rounded mt-1 break-all">
+										{job.adapter_path}
+									</p>
+								</div>
+							)}
+							{job.wandb_url && (
+								<div>
+									<span className="text-sm font-medium text-muted-foreground">
+										Weights & Biases
+									</span>
+									<a
+										href={job.wandb_url}
+										target="_blank"
+										rel="noopener noreferrer"
+										className="text-blue-600 hover:text-blue-800 underline text-sm mt-1 block"
+									>
+										View Training Logs →
+									</a>
+								</div>
+							)}
+							{job.error && (
+								<div>
+									<span className="text-sm font-medium text-muted-foreground text-red-600">
+										Error
+									</span>
+									<div className="text-sm text-red-600 bg-red-50 px-2 py-1 rounded mt-1 border border-red-200">
+										{job.error}
+									</div>
+								</div>
+							)}
+						</div>
+					</CardContent>
+				</Card>
+			</div>
+
+			{/* Evaluation Metrics */}
+			{job.metrics && (
+				<Card>
+					<CardHeader>
+						<h3 className="text-lg font-semibold">
+							Evaluation Metrics
+						</h3>
+						<p className="text-sm text-muted-foreground">
+							Performance metrics from training evaluation
+						</p>
+					</CardHeader>
+					<CardContent>
+						<div className="grid md:grid-cols-3 gap-4">
+							{job.metrics.accuracy !== undefined && (
+								<div className="bg-gradient-to-br from-blue-50 to-blue-100 p-4 rounded-lg border">
+									<div className="text-2xl font-bold text-blue-700">
+										{(job.metrics.accuracy * 100).toFixed(
+											2,
+										)}
+										%
+									</div>
+									<div className="text-sm text-blue-600 font-medium">
+										Accuracy
+									</div>
+								</div>
+							)}
+							{job.metrics.perplexity !== undefined && (
+								<div className="bg-gradient-to-br from-green-50 to-green-100 p-4 rounded-lg border">
+									<div className="text-2xl font-bold text-green-700">
+										{job.metrics.perplexity.toFixed(3)}
+									</div>
+									<div className="text-sm text-green-600 font-medium">
+										Perplexity
+									</div>
+								</div>
+							)}
+							{job.metrics.eval_loss !== undefined && (
+								<div className="bg-gradient-to-br from-purple-50 to-purple-100 p-4 rounded-lg border">
+									<div className="text-2xl font-bold text-purple-700">
+										{job.metrics.eval_loss.toFixed(4)}
+									</div>
+									<div className="text-sm text-purple-600 font-medium">
+										Evaluation Loss
+									</div>
+								</div>
+							)}
+						</div>
+					</CardContent>
+				</Card>
+			)}
+
+			{/* Actions */}
+			{job.status === "completed" && job.adapter_path && (
+				<Card>
+					<CardHeader>
+						<h3 className="text-lg font-semibold">
+							Available Actions
+						</h3>
+						<p className="text-sm text-muted-foreground">
+							What you can do with your trained model
+						</p>
+					</CardHeader>
+					<CardContent>
+						<div className="flex gap-3">
+							<Link
+								href={`/dashboard/training/${jobId}/batch`}
+								className="flex-1"
+							>
+								<Button variant="outline" className="w-full">
+									Batch Inference
+								</Button>
+							</Link>
+						</div>
+					</CardContent>
+				</Card>
+			)}
 		</div>
 	);
 }

--- a/src/app/dashboard/training/new/configuration/page.tsx
+++ b/src/app/dashboard/training/new/configuration/page.tsx
@@ -71,9 +71,10 @@ export default function TrainingConfigPage() {
 			compute_eval_metrics: false,
 			batch_eval_metrics: false,
 			export_format: "adapter",
-			export_quantization: "q4",
 			export_destination: "gcs",
 			hf_repo_id: "",
+			include_gguf: false,
+			gguf_quantization: "none",
 			wandb_api_key: "",
 			wandb_project: "",
 			wandb_log_model: "end",
@@ -354,42 +355,6 @@ export default function TrainingConfigPage() {
 											value: "merged",
 											label: "Merged Model",
 										},
-										{ value: "gguf", label: "GGUF Format" },
-									],
-								})}
-								{SelectInput({
-									field: "export_quantization",
-									label: "Quantization",
-									options: [
-										{
-											value: "fp32",
-											label: "FP32 (No Quantization)",
-										},
-										{
-											value: "fp16",
-											label: "FP16 (Half Precision)",
-										},
-										{ value: "q8", label: "Q8 (8-bit)" },
-										{
-											value: "q4",
-											label: "Q4 (4-bit, Recommended)",
-										},
-										{
-											value: "q5",
-											label: "Q5 (5-bit, GGUF only)",
-										},
-										{
-											value: "not_quantized",
-											label: "Not Quantized (GGUF)",
-										},
-										{
-											value: "fast_quantized",
-											label: "Fast Quantized (GGUF)",
-										},
-										{
-											value: "quantized",
-											label: "Quantized (GGUF)",
-										},
 									],
 								})}
 								{SelectInput({
@@ -403,6 +368,36 @@ export default function TrainingConfigPage() {
 										{
 											value: "hfhub",
 											label: "Hugging Face Hub",
+										},
+									],
+								})}
+								{CheckboxInput({
+									field: "include_gguf",
+									label: "Include GGUF Export",
+								})}
+								{SelectInput({
+									field: "gguf_quantization",
+									label: "GGUF Quantization (if enabled)",
+									options: [
+										{
+											value: "none",
+											label: "No Quantization",
+										},
+										{
+											value: "f16",
+											label: "FP16 (Half Precision)",
+										},
+										{
+											value: "bf16",
+											label: "BF16 (Brain Float 16)",
+										},
+										{
+											value: "q8_0",
+											label: "Q8_0 (8-bit)",
+										},
+										{
+											value: "q4_k_m",
+											label: "Q4_K_M (4-bit)",
 										},
 									],
 								})}

--- a/src/app/dashboard/training/new/configuration/page.tsx
+++ b/src/app/dashboard/training/new/configuration/page.tsx
@@ -50,27 +50,50 @@ export default function TrainingConfigPage() {
 	if (!config) {
 		setConfig({
 			method: "QLoRA",
-			lora_rank: 4,
+			base_model_id: model?.modelId ?? "",
+			lora_rank: 16,
 			lora_alpha: 16,
 			lora_dropout: 0.05,
 			learning_rate: 2e-4,
-			batch_size: 2,
-			epochs: 1,
-			max_steps: 100,
-			max_seq_length: 1024,
+			batch_size: 4,
+			epochs: 3,
+			max_steps: -1,
 			gradient_accumulation_steps: 4,
+			packing: false,
+			use_fa2: false,
 			provider: model?.provider ?? "huggingface",
-			export: "hfhub",
+			modality: "text",
+			lr_scheduler_type: "linear",
+			save_strategy: "epoch",
+			logging_steps: 10,
+			eval_strategy: "no",
+			eval_steps: 50,
+			compute_eval_metrics: false,
+			batch_eval_metrics: false,
+			export_format: "adapter",
+			export_quantization: "q4",
+			export_destination: "gcs",
 			hf_repo_id: "",
 			wandb_api_key: "",
 			wandb_project: "",
+			wandb_log_model: "end",
 		});
 		return null; // render after state set
 	}
 
-	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const { name, value } = e.target;
-		setConfig(prev => (prev ? { ...prev, [name]: value } : null));
+	const handleChange = (
+		e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+	) => {
+		const { name, value, type } = e.target;
+		let processedValue: unknown = value;
+
+		if (type === "checkbox") {
+			processedValue = (e.target as HTMLInputElement).checked;
+		} else if (type === "number") {
+			processedValue = Number.parseFloat(value) || 0;
+		}
+
+		setConfig(prev => (prev ? { ...prev, [name]: processedValue } : null));
 	};
 
 	const handleNext = () => {
@@ -89,9 +112,52 @@ export default function TrainingConfigPage() {
 				name={field}
 				type="number"
 				step={step}
-				value={config?.[field] ?? ""}
+				value={String(config?.[field] ?? "")}
 				onChange={handleChange}
 			/>
+		</div>
+	);
+
+	const SelectInput = ({
+		field,
+		label,
+		options,
+	}: {
+		field: keyof TrainingConfigType;
+		label: string;
+		options: { value: string; label: string }[];
+	}) => (
+		<div className="space-y-1">
+			<Label htmlFor={field}>{label}</Label>
+			<select
+				id={field}
+				name={field}
+				value={String(config?.[field] ?? "")}
+				onChange={handleChange}
+				className="w-full p-2 border rounded"
+			>
+				{options.map(option => (
+					<option key={option.value} value={option.value}>
+						{option.label}
+					</option>
+				))}
+			</select>
+		</div>
+	);
+
+	const CheckboxInput = ({
+		field,
+		label,
+	}: { field: keyof TrainingConfigType; label: string }) => (
+		<div className="flex items-center space-x-2">
+			<input
+				id={field}
+				name={field}
+				type="checkbox"
+				checked={Boolean(config?.[field])}
+				onChange={handleChange}
+			/>
+			<Label htmlFor={field}>{label}</Label>
 		</div>
 	);
 
@@ -104,7 +170,9 @@ export default function TrainingConfigPage() {
 				<CardContent>
 					<Accordion type="single" collapsible defaultValue="basic">
 						<AccordionItem value="basic">
-							<AccordionTrigger>Basic</AccordionTrigger>
+							<AccordionTrigger>
+								Basic Training Settings
+							</AccordionTrigger>
 							<AccordionContent className="grid md:grid-cols-2 gap-4 py-4">
 								<div className="space-y-1 md:col-span-2">
 									<Label>Job Name</Label>
@@ -116,14 +184,30 @@ export default function TrainingConfigPage() {
 										}
 									/>
 								</div>
-								<div className="space-y-1">
-									<Label>Method</Label>
-									<Input
-										name="method"
-										value={config?.method ?? ""}
-										onChange={handleChange}
-									/>
-								</div>
+								{SelectInput({
+									field: "method",
+									label: "Training Method",
+									options: [
+										{
+											value: "Full",
+											label: "Full Fine-tuning",
+										},
+										{ value: "LoRA", label: "LoRA" },
+										{ value: "QLoRA", label: "QLoRA" },
+										{
+											value: "RL",
+											label: "Reinforcement Learning",
+										},
+									],
+								})}
+								{SelectInput({
+									field: "modality",
+									label: "Training Modality",
+									options: [
+										{ value: "text", label: "Text" },
+										{ value: "vision", label: "Vision" },
+									],
+								})}
 								{NumberInput({
 									field: "batch_size",
 									label: "Batch Size",
@@ -137,10 +221,18 @@ export default function TrainingConfigPage() {
 									label: "Learning Rate",
 									step: 0.00001,
 								})}
+								{NumberInput({
+									field: "gradient_accumulation_steps",
+									label: "Gradient Accumulation Steps",
+								})}
+								{NumberInput({
+									field: "max_steps",
+									label: "Max Steps (-1 for no limit)",
+								})}
 							</AccordionContent>
 						</AccordionItem>
-						<AccordionItem value="advanced">
-							<AccordionTrigger>Advanced</AccordionTrigger>
+						<AccordionItem value="lora">
+							<AccordionTrigger>LoRA Settings</AccordionTrigger>
 							<AccordionContent className="grid md:grid-cols-2 gap-4 py-4">
 								{NumberInput({
 									field: "lora_rank",
@@ -155,35 +247,192 @@ export default function TrainingConfigPage() {
 									label: "LoRA Dropout",
 									step: 0.01,
 								})}
-								{NumberInput({
-									field: "max_steps",
-									label: "Max Steps",
+							</AccordionContent>
+						</AccordionItem>
+						<AccordionItem value="evaluation">
+							<AccordionTrigger>
+								Evaluation Settings
+							</AccordionTrigger>
+							<AccordionContent className="grid md:grid-cols-2 gap-4 py-4">
+								{SelectInput({
+									field: "eval_strategy",
+									label: "Evaluation Strategy",
+									options: [
+										{ value: "no", label: "No Evaluation" },
+										{
+											value: "steps",
+											label: "Evaluate Every N Steps",
+										},
+										{
+											value: "epoch",
+											label: "Evaluate Every Epoch",
+										},
+									],
 								})}
+								{NumberInput({
+									field: "eval_steps",
+									label: "Evaluation Steps",
+								})}
+								{CheckboxInput({
+									field: "compute_eval_metrics",
+									label: "Compute Eval Metrics (accuracy, perplexity)",
+								})}
+								{CheckboxInput({
+									field: "batch_eval_metrics",
+									label: "Enable Batch Eval Mode",
+								})}
+							</AccordionContent>
+						</AccordionItem>
+						<AccordionItem value="advanced">
+							<AccordionTrigger>
+								Advanced Settings
+							</AccordionTrigger>
+							<AccordionContent className="grid md:grid-cols-2 gap-4 py-4">
 								{NumberInput({
 									field: "max_seq_length",
-									label: "Max Seq Length",
+									label: "Max Sequence Length",
+								})}
+								{SelectInput({
+									field: "lr_scheduler_type",
+									label: "Learning Rate Scheduler",
+									options: [
+										{ value: "linear", label: "Linear" },
+										{ value: "cosine", label: "Cosine" },
+										{
+											value: "polynomial",
+											label: "Polynomial",
+										},
+										{
+											value: "constant",
+											label: "Constant",
+										},
+									],
+								})}
+								{SelectInput({
+									field: "save_strategy",
+									label: "Save Strategy",
+									options: [
+										{
+											value: "epoch",
+											label: "Save Every Epoch",
+										},
+										{
+											value: "steps",
+											label: "Save Every N Steps",
+										},
+										{ value: "no", label: "No Saving" },
+									],
 								})}
 								{NumberInput({
-									field: "gradient_accumulation_steps",
-									label: "Grad Accum Steps",
+									field: "logging_steps",
+									label: "Logging Steps",
+								})}
+								{CheckboxInput({
+									field: "packing",
+									label: "Enable Sequence Packing",
+								})}
+								{CheckboxInput({
+									field: "use_fa2",
+									label: "Use Flash Attention 2 (HuggingFace only)",
+								})}
+							</AccordionContent>
+						</AccordionItem>
+						<AccordionItem value="export">
+							<AccordionTrigger>
+								Export Configuration
+							</AccordionTrigger>
+							<AccordionContent className="grid md:grid-cols-2 gap-4 py-4">
+								{SelectInput({
+									field: "export_format",
+									label: "Export Format",
+									options: [
+										{
+											value: "adapter",
+											label: "Adapter Only",
+										},
+										{
+											value: "merged",
+											label: "Merged Model",
+										},
+										{ value: "gguf", label: "GGUF Format" },
+									],
+								})}
+								{SelectInput({
+									field: "export_quantization",
+									label: "Quantization",
+									options: [
+										{
+											value: "fp32",
+											label: "FP32 (No Quantization)",
+										},
+										{
+											value: "fp16",
+											label: "FP16 (Half Precision)",
+										},
+										{ value: "q8", label: "Q8 (8-bit)" },
+										{
+											value: "q4",
+											label: "Q4 (4-bit, Recommended)",
+										},
+										{
+											value: "q5",
+											label: "Q5 (5-bit, GGUF only)",
+										},
+										{
+											value: "not_quantized",
+											label: "Not Quantized (GGUF)",
+										},
+										{
+											value: "fast_quantized",
+											label: "Fast Quantized (GGUF)",
+										},
+										{
+											value: "quantized",
+											label: "Quantized (GGUF)",
+										},
+									],
+								})}
+								{SelectInput({
+									field: "export_destination",
+									label: "Export Destination",
+									options: [
+										{
+											value: "gcs",
+											label: "Google Cloud Storage",
+										},
+										{
+											value: "hfhub",
+											label: "Hugging Face Hub",
+										},
+									],
 								})}
 								<div className="space-y-1 md:col-span-2">
-									<Label>HF Repo ID</Label>
+									<Label>
+										HuggingFace Repo ID (for HF Hub export)
+									</Label>
 									<Input
 										name="hf_repo_id"
 										value={config?.hf_repo_id ?? ""}
 										onChange={handleChange}
 									/>
 								</div>
+							</AccordionContent>
+						</AccordionItem>
+						<AccordionItem value="wandb">
+							<AccordionTrigger>
+								Weights & Biases
+							</AccordionTrigger>
+							<AccordionContent className="grid md:grid-cols-2 gap-4 py-4">
 								<div className="space-y-1 md:col-span-2">
 									<Label>WandB API Key</Label>
 									<Input
 										name="wandb_api_key"
+										type="password"
 										value={config?.wandb_api_key ?? ""}
 										onChange={handleChange}
 									/>
 								</div>
-								<div className="space-y-1 md:col-span-2">
+								<div className="space-y-1">
 									<Label>WandB Project</Label>
 									<Input
 										name="wandb_project"
@@ -191,6 +440,24 @@ export default function TrainingConfigPage() {
 										onChange={handleChange}
 									/>
 								</div>
+								{SelectInput({
+									field: "wandb_log_model",
+									label: "Log Model to WandB",
+									options: [
+										{
+											value: "false",
+											label: "Don't Log Model",
+										},
+										{
+											value: "checkpoint",
+											label: "Log Checkpoints",
+										},
+										{
+											value: "end",
+											label: "Log Final Model",
+										},
+									],
+								})}
 							</AccordionContent>
 						</AccordionItem>
 					</Accordion>

--- a/src/app/dashboard/training/new/dataset/page.tsx
+++ b/src/app/dashboard/training/new/dataset/page.tsx
@@ -90,9 +90,9 @@ export default function DatasetSelectionPage() {
 								</span>
 							</div>
 							<div className="text-xs text-muted-foreground mb-1">
-								Subset:{" "}
+								Splits:{" "}
 								<span className="text-foreground font-medium">
-									{ds.datasetSubset}
+									{ds.splits.join(", ")}
 								</span>
 							</div>
 							<div className="text-xs text-muted-foreground">

--- a/src/app/dashboard/training/new/review/page.tsx
+++ b/src/app/dashboard/training/new/review/page.tsx
@@ -47,7 +47,7 @@ export default function TrainingReviewPage() {
 	}, [model, datasetId, config, router]);
 	if (!model || !datasetId || !config) return null;
 
-	const exportType = config.hf_repo_id.trim() ? "hfhub" : "gcs";
+	const exportDestination = config.export_destination || "gcs";
 
 	const handleSubmit = async () => {
 		setSubmitting(true);
@@ -60,27 +60,41 @@ export default function TrainingReviewPage() {
 				training_config: {
 					method: config.method,
 					base_model_id: model.modelId,
-					lora_rank: Number(config.lora_rank),
-					lora_alpha: Number(config.lora_alpha),
-					lora_dropout: Number(config.lora_dropout),
-					learning_rate: Number(config.learning_rate),
-					batch_size: Number(config.batch_size),
-					epochs: Number(config.epochs),
-					max_steps: Number(config.max_steps),
-					max_seq_length: Number(config.max_seq_length),
-					gradient_accumulation_steps: Number(
+					lora_rank: config.lora_rank,
+					lora_alpha: config.lora_alpha,
+					lora_dropout: config.lora_dropout,
+					learning_rate: config.learning_rate,
+					batch_size: config.batch_size,
+					gradient_accumulation_steps:
 						config.gradient_accumulation_steps,
-					),
+					epochs: config.epochs,
+					max_steps: config.max_steps,
+					packing: config.packing,
+					use_fa2: config.use_fa2,
 					provider: model.provider,
+					modality: config.modality,
+					max_seq_length: config.max_seq_length,
+					lr_scheduler_type: config.lr_scheduler_type,
+					save_strategy: config.save_strategy,
+					logging_steps: config.logging_steps,
+					eval_strategy: config.eval_strategy,
+					eval_steps: config.eval_steps,
+					compute_eval_metrics: config.compute_eval_metrics,
+					batch_eval_metrics: config.batch_eval_metrics,
 				},
-				export: exportType,
-				hf_repo_id: config.hf_repo_id,
-				wandb_config: {
-					api_key: config.wandb_api_key,
-					project: config.wandb_project,
+				export_config: {
+					format: config.export_format || "adapter",
+					quantization: config.export_quantization || "q4",
+					destination: exportDestination,
+					hf_repo_id: config.hf_repo_id,
 				},
-				// modality is not one of the config because it should not be changed by the user
-				modality: modality || "text",
+				wandb_config: config.wandb_api_key
+					? {
+							api_key: config.wandb_api_key,
+							project: config.wandb_project,
+							log_model: config.wandb_log_model,
+						}
+					: undefined,
 			};
 			const res = await fetch("/api/jobs", {
 				method: "POST",
@@ -146,8 +160,8 @@ export default function TrainingReviewPage() {
 					})}
 					{SummaryRow({
 						label: "Modality",
-						value: modality || "text",
-						editLink: "",
+						value: config.modality || "text",
+						editLink: "/dashboard/training/new/configuration",
 					})}
 					{SummaryRow({
 						label: "Dataset",
@@ -160,20 +174,43 @@ export default function TrainingReviewPage() {
 						editLink: "/dashboard/training/new/configuration",
 					})}
 					{SummaryRow({
-						label: "Export",
-						value: exportType,
+						label: "Export Destination",
+						value: exportDestination,
+						editLink: "/dashboard/training/new/configuration",
+					})}
+					{SummaryRow({
+						label: "Export Format",
+						value: config.export_format || "adapter",
 						editLink: "/dashboard/training/new/configuration",
 					})}
 					{SummaryRow({
 						label: "Batch Size",
-						value: config.batch_size.toString(),
+						value: String(config.batch_size),
 						editLink: "/dashboard/training/new/configuration",
 					})}
 					{SummaryRow({
 						label: "Epochs",
-						value: config.epochs.toString(),
+						value: String(config.epochs),
 						editLink: "/dashboard/training/new/configuration",
 					})}
+					{SummaryRow({
+						label: "Learning Rate",
+						value: String(config.learning_rate),
+						editLink: "/dashboard/training/new/configuration",
+					})}
+					{config.eval_strategy &&
+						config.eval_strategy !== "no" &&
+						SummaryRow({
+							label: "Evaluation Strategy",
+							value: config.eval_strategy,
+							editLink: "/dashboard/training/new/configuration",
+						})}
+					{config.compute_eval_metrics &&
+						SummaryRow({
+							label: "Compute Evaluation Metrics",
+							value: "Yes (accuracy, perplexity)",
+							editLink: "/dashboard/training/new/configuration",
+						})}
 					{/* Add more key fields if needed */}
 				</CardContent>
 				{error && (

--- a/src/app/dashboard/training/new/review/page.tsx
+++ b/src/app/dashboard/training/new/review/page.tsx
@@ -84,9 +84,10 @@ export default function TrainingReviewPage() {
 				},
 				export_config: {
 					format: config.export_format || "adapter",
-					quantization: config.export_quantization || "q4",
 					destination: exportDestination,
 					hf_repo_id: config.hf_repo_id,
+					include_gguf: config.include_gguf || false,
+					gguf_quantization: config.gguf_quantization || "none",
 				},
 				wandb_config: config.wandb_api_key
 					? {
@@ -183,6 +184,19 @@ export default function TrainingReviewPage() {
 						value: config.export_format || "adapter",
 						editLink: "/dashboard/training/new/configuration",
 					})}
+					{config.include_gguf &&
+						SummaryRow({
+							label: "Include GGUF Export",
+							value: "Yes",
+							editLink: "/dashboard/training/new/configuration",
+						})}
+					{config.include_gguf &&
+						config.gguf_quantization &&
+						SummaryRow({
+							label: "GGUF Quantization",
+							value: config.gguf_quantization,
+							editLink: "/dashboard/training/new/configuration",
+						})}
 					{SummaryRow({
 						label: "Batch Size",
 						value: String(config.batch_size),

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -162,18 +162,11 @@ export type TrainingConfigType = {
 	compute_eval_metrics?: boolean;
 	batch_eval_metrics?: boolean;
 	// Export config
-	export_format?: "adapter" | "merged" | "gguf";
-	export_quantization?:
-		| "fp32"
-		| "fp16"
-		| "q8"
-		| "q4"
-		| "q5"
-		| "not_quantized"
-		| "fast_quantized"
-		| "quantized";
+	export_format?: "adapter" | "merged";
 	export_destination?: "gcs" | "hfhub";
 	hf_repo_id?: string;
+	include_gguf?: boolean;
+	gguf_quantization?: "none" | "f16" | "bf16" | "q8_0" | "q4_k_m";
 	// WandB config
 	wandb_api_key?: string;
 	wandb_project?: string;

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -139,21 +139,45 @@ export const trainingModelAtom = atom<TrainingModelType | null>(null);
 export const trainingDatasetIdAtom = atom<string>("");
 export const trainingDatasetModalityAtom = atom<"text" | "vision" | null>(null);
 export type TrainingConfigType = {
-	method: string;
-	lora_rank: number;
-	lora_alpha: number;
-	lora_dropout: number;
+	method: "Full" | "LoRA" | "QLoRA" | "RL";
+	base_model_id: string;
+	lora_rank?: number;
+	lora_alpha?: number;
+	lora_dropout?: number;
 	learning_rate: number;
 	batch_size: number;
-	epochs: number;
-	max_steps: number;
-	max_seq_length: number;
 	gradient_accumulation_steps: number;
+	epochs: number;
+	max_steps?: number;
+	packing?: boolean;
+	use_fa2?: boolean;
 	provider: "unsloth" | "huggingface";
-	export: string;
-	hf_repo_id: string;
-	wandb_api_key: string;
-	wandb_project: string;
+	modality: "text" | "vision";
+	max_seq_length?: number;
+	lr_scheduler_type?: string;
+	save_strategy?: string;
+	logging_steps?: number;
+	eval_strategy?: "no" | "steps" | "epoch";
+	eval_steps?: number;
+	compute_eval_metrics?: boolean;
+	batch_eval_metrics?: boolean;
+	// Export config
+	export_format?: "adapter" | "merged" | "gguf";
+	export_quantization?:
+		| "fp32"
+		| "fp16"
+		| "q8"
+		| "q4"
+		| "q5"
+		| "not_quantized"
+		| "fast_quantized"
+		| "quantized";
+	export_destination?: "gcs" | "hfhub";
+	hf_repo_id?: string;
+	// WandB config
+	wandb_api_key?: string;
+	wandb_project?: string;
+	wandb_log_model?: "false" | "checkpoint" | "end";
 	hf_token?: string;
 };
 export const trainingConfigAtom = atom<TrainingConfigType | null>(null);

--- a/src/components/batch-inference-form.tsx
+++ b/src/components/batch-inference-form.tsx
@@ -88,13 +88,12 @@ export default function BatchInferenceForm({
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
-					job_id_or_repo_id: jobId,
+					hf_token: "your_hf_token", // TODO: Get from user settings
+					adapter_path: job?.adapter_path,
+					base_model_id: job?.base_model_id,
 					messages: selected.map(s =>
 						getInferenceMessages(s.messages),
 					),
-					storage_type: job?.adapter_path?.startsWith("gs://")
-						? "gcs"
-						: "hfhub",
 				}),
 			});
 			const data = (await res.json()) as BatchInferenceResult;

--- a/src/components/evaluation-form.tsx
+++ b/src/components/evaluation-form.tsx
@@ -1,0 +1,410 @@
+import { MessageDisplay } from "@/components/message-display";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import type { DatasetMessage } from "@/types/dataset";
+import type {
+	ApiErrorResponse,
+	EvaluationRequest,
+	EvaluationResponse,
+	MetricType,
+	TaskType,
+} from "@/types/inference";
+import type { TrainingJob } from "@/types/training";
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+import type { ReactElement } from "react";
+
+interface EvaluationFormProps {
+	job: TrainingJob;
+}
+
+const TASK_TYPES: { value: TaskType; label: string }[] = [
+	{ value: "conversation", label: "Conversation" },
+	{ value: "qa", label: "Question Answering" },
+	{ value: "summarization", label: "Summarization" },
+	{ value: "translation", label: "Translation" },
+	{ value: "classification", label: "Classification" },
+	{ value: "general", label: "General" },
+];
+
+const METRIC_TYPES: { value: MetricType; label: string }[] = [
+	{ value: "rouge", label: "ROUGE" },
+	{ value: "bertscore", label: "BERTScore" },
+	{ value: "accuracy", label: "Accuracy" },
+	{ value: "exact_match", label: "Exact Match" },
+	{ value: "bleu", label: "BLEU" },
+	{ value: "meteor", label: "METEOR" },
+	{ value: "recall", label: "Recall" },
+	{ value: "precision", label: "Precision" },
+	{ value: "f1", label: "F1 Score" },
+];
+
+export default function EvaluationForm({ job }: EvaluationFormProps) {
+	const [dataset, setDataset] = useState<string>(
+		job.processed_dataset_id || "",
+	);
+	const [evaluationType, setEvaluationType] = useState<"task" | "metrics">(
+		"task",
+	);
+	const [taskType, setTaskType] = useState<TaskType>("conversation");
+	const [selectedMetrics, setSelectedMetrics] = useState<MetricType[]>([]);
+	const [maxSamples, setMaxSamples] = useState<string>("");
+	const [numSampleResults, setNumSampleResults] = useState<string>("3");
+	const [loading, setLoading] = useState(false);
+	const [results, setResults] = useState<EvaluationResponse | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	function handleMetricToggle(metric: MetricType, checked: boolean) {
+		if (checked) {
+			setSelectedMetrics(prev => [...prev, metric]);
+		} else {
+			setSelectedMetrics(prev => prev.filter(m => m !== metric));
+		}
+	}
+
+	async function runEvaluation() {
+		setLoading(true);
+		setError(null);
+		setResults(null);
+		try {
+			if (!job.adapter_path || !job.base_model_id) {
+				throw new Error("Job is missing adapter path or base model ID");
+			}
+
+			const requestBody: EvaluationRequest = {
+				adapter_path: job.adapter_path,
+				base_model_id: job.base_model_id,
+				dataset_id: dataset,
+				num_sample_results: Number.parseInt(numSampleResults) || 3,
+			};
+
+			if (evaluationType === "task") {
+				requestBody.task_type = taskType;
+			} else {
+				requestBody.metrics = selectedMetrics;
+			}
+
+			if (maxSamples) {
+				requestBody.max_samples = Number.parseInt(maxSamples);
+			}
+
+			const res = await fetch("/api/evaluation", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(requestBody),
+			});
+			const data = (await res.json()) as
+				| EvaluationResponse
+				| ApiErrorResponse;
+			if (!res.ok)
+				throw new Error(
+					(data as ApiErrorResponse).error || "Evaluation failed",
+				);
+			setResults(data as EvaluationResponse);
+		} catch (err: unknown) {
+			setError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setLoading(false);
+		}
+	}
+
+	function formatMetricValue(
+		value: number | Record<string, number>,
+	): ReactElement | string {
+		if (typeof value === "number") {
+			return value.toFixed(4);
+		}
+
+		// Handle nested metrics as a table
+		return (
+			<div className="space-y-1">
+				{Object.entries(value).map(([key, val]) => (
+					<div key={key} className="flex justify-between text-xs">
+						<span className="text-muted-foreground capitalize">
+							{key.replace(/_/g, " ")}:
+						</span>
+						<span className="font-medium">
+							{typeof val === "number"
+								? val.toFixed(4)
+								: String(val)}
+						</span>
+					</div>
+				))}
+			</div>
+		);
+	}
+
+	function parseMessages(input: Array<DatasetMessage>): DatasetMessage[] {
+		try {
+			return input as DatasetMessage[];
+		} catch {
+			return [];
+		}
+	}
+
+	return (
+		<div className="flex flex-col gap-6">
+			<div className="space-y-6">
+				<div>
+					<Label htmlFor="dataset">Dataset Name</Label>
+					<Input
+						id="dataset"
+						value={dataset}
+						onChange={e => setDataset(e.target.value)}
+						placeholder="Enter dataset name..."
+						disabled={loading}
+						className="mt-2"
+					/>
+				</div>
+
+				<div>
+					<Label>Evaluation Type</Label>
+					<div className="flex gap-4 mt-3">
+						<label className="flex items-center gap-2">
+							<input
+								type="radio"
+								name="evaluationType"
+								value="task"
+								checked={evaluationType === "task"}
+								onChange={e =>
+									setEvaluationType(e.target.value as "task")
+								}
+								disabled={loading}
+							/>
+							Task Type (Recommended)
+						</label>
+						<label className="flex items-center gap-2">
+							<input
+								type="radio"
+								name="evaluationType"
+								value="metrics"
+								checked={evaluationType === "metrics"}
+								onChange={e =>
+									setEvaluationType(
+										e.target.value as "metrics",
+									)
+								}
+								disabled={loading}
+							/>
+							Specific Metrics
+						</label>
+					</div>
+				</div>
+
+				{evaluationType === "task" ? (
+					<div>
+						<Label htmlFor="taskType">Task Type</Label>
+						<Select
+							value={taskType}
+							onValueChange={(value: TaskType) =>
+								setTaskType(value)
+							}
+							disabled={loading}
+						>
+							<SelectTrigger className="mt-2">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{TASK_TYPES.map(type => (
+									<SelectItem
+										key={type.value}
+										value={type.value}
+									>
+										{type.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				) : (
+					<div>
+						<Label>Select Metrics</Label>
+						<div className="grid grid-cols-2 gap-2 mt-3">
+							{METRIC_TYPES.map(metric => (
+								<div
+									key={metric.value}
+									className="flex items-center space-x-2"
+								>
+									<Checkbox
+										id={metric.value}
+										checked={selectedMetrics.includes(
+											metric.value,
+										)}
+										onCheckedChange={checked =>
+											handleMetricToggle(
+												metric.value,
+												checked as boolean,
+											)
+										}
+										disabled={loading}
+									/>
+									<Label
+										htmlFor={metric.value}
+										className="text-sm"
+									>
+										{metric.label}
+									</Label>
+								</div>
+							))}
+						</div>
+					</div>
+				)}
+
+				<div className="grid grid-cols-2 gap-4">
+					<div>
+						<Label htmlFor="maxSamples">
+							Max Samples (Optional)
+						</Label>
+						<Input
+							id="maxSamples"
+							type="number"
+							value={maxSamples}
+							onChange={e => setMaxSamples(e.target.value)}
+							placeholder="All samples"
+							disabled={loading}
+							className="mt-2"
+						/>
+					</div>
+					<div>
+						<Label htmlFor="numSampleResults">
+							Sample Results to Show
+						</Label>
+						<Input
+							id="numSampleResults"
+							type="number"
+							value={numSampleResults}
+							onChange={e => setNumSampleResults(e.target.value)}
+							placeholder="3"
+							disabled={loading}
+							className="mt-2"
+						/>
+					</div>
+				</div>
+
+				<Button
+					onClick={runEvaluation}
+					disabled={
+						!dataset ||
+						(evaluationType === "metrics" &&
+							selectedMetrics.length === 0) ||
+						loading
+					}
+					className="w-fit"
+				>
+					{loading ? (
+						<>
+							<Loader2 className="animate-spin w-4 h-4 mr-2" />
+							Running Evaluation...
+						</>
+					) : (
+						"Run Evaluation"
+					)}
+				</Button>
+			</div>
+
+			{error && (
+				<div className="text-red-600 text-sm p-3 bg-red-50 rounded border border-red-200">
+					{error}
+				</div>
+			)}
+
+			{results && (
+				<div className="space-y-6">
+					<div>
+						<h3 className="font-semibold text-lg mb-4">
+							Evaluation Results
+						</h3>
+						<div className="grid gap-4">
+							<div className="bg-muted p-4 rounded-lg">
+								<div className="text-sm text-muted-foreground mb-2">
+									Evaluated {results.num_samples} samples from
+									dataset: {results.dataset_id}
+								</div>
+							</div>
+
+							<div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+								{Object.entries(results.metrics).map(
+									([metric, value]) => (
+										<div
+											key={metric}
+											className="bg-gradient-to-br from-blue-50 to-blue-100 p-4 rounded-lg border"
+										>
+											<div className="text-lg font-bold text-blue-700 min-h-[2rem] flex items-start">
+												{formatMetricValue(value)}
+											</div>
+											<div className="text-sm text-blue-600 font-medium capitalize mt-2">
+												{metric.replace("_", " ")}
+											</div>
+										</div>
+									),
+								)}
+							</div>
+						</div>
+					</div>
+
+					{results.samples.length > 0 && (
+						<div>
+							<h4 className="font-semibold mb-4">
+								Sample Results
+							</h4>
+							<div className="space-y-4">
+								{results.samples.map((sample, index) => (
+									<div
+										key={sample.sample_index}
+										className="border rounded-lg p-4 space-y-3 bg-muted/50"
+									>
+										<div className="text-sm font-medium text-muted-foreground">
+											Sample #{sample.sample_index + 1}
+										</div>
+
+										{sample.input && (
+											<div>
+												<span className="text-xs text-muted-foreground block mb-2">
+													Input:
+												</span>
+												<div className="bg-input/10 p-3 rounded text-sm">
+													<MessageDisplay
+														messages={parseMessages(
+															sample.input,
+														)}
+													/>
+												</div>
+											</div>
+										)}
+
+										<div>
+											<span className="text-xs text-muted-foreground block mb-2">
+												Model Prediction:
+											</span>
+											<div className="bg-input/10 p-3 rounded text-sm whitespace-pre-wrap">
+												{sample.prediction}
+											</div>
+										</div>
+
+										<div>
+											<span className="text-xs text-muted-foreground block mb-2">
+												Ground Truth:
+											</span>
+											<div className="bg-input/10 p-3 rounded text-sm whitespace-pre-wrap">
+												{sample.reference}
+											</div>
+										</div>
+									</div>
+								))}
+							</div>
+						</div>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/components/message-display.tsx
+++ b/src/components/message-display.tsx
@@ -1,0 +1,60 @@
+import type { DatasetMessage } from "@/types/dataset";
+import Image from "next/image";
+
+interface MessageDisplayProps {
+	messages: DatasetMessage[];
+	className?: string;
+}
+
+export function MessageDisplay({
+	messages,
+	className = "",
+}: MessageDisplayProps) {
+	return (
+		<div className={`space-y-1 text-sm ${className}`}>
+			{messages.map((msg, idx) => {
+				const contentKey =
+					typeof msg.content === "string"
+						? msg.content.slice(0, 20)
+						: msg.content
+								.map(part =>
+									part.type === "text"
+										? part.text.slice(0, 20)
+										: part.image.slice(0, 20),
+								)
+								.join("-");
+				return (
+					<div
+						key={`${msg.role}-${contentKey}-${idx}`}
+						className="space-y-1"
+					>
+						{typeof msg.content === "string" ? (
+							<p>
+								<b>{msg.role}:</b> {msg.content}
+							</p>
+						) : (
+							<div className="flex flex-col gap-2">
+								{msg.content.map((part, partIdx) =>
+									part.type === "text" ? (
+										<p key={`${part.text}-${partIdx}`}>
+											<b>{msg.role}:</b> {part.text}
+										</p>
+									) : (
+										<Image
+											key={`${part.image}-${partIdx}`}
+											src={part.image}
+											alt=""
+											width={200}
+											height={200}
+											className="rounded-md"
+										/>
+									),
+								)}
+							</div>
+						)}
+					</div>
+				);
+			})}
+		</div>
+	);
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+	React.ElementRef<typeof DialogPrimitive.Overlay>,
+	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+	<DialogPrimitive.Overlay
+		ref={ref}
+		className={cn(
+			"fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+			className,
+		)}
+		{...props}
+	/>
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+	React.ElementRef<typeof DialogPrimitive.Content>,
+	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+	<DialogPortal>
+		<DialogOverlay />
+		<DialogPrimitive.Content
+			ref={ref}
+			className={cn(
+				"fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+			<DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+				<X className="h-4 w-4" />
+				<span className="sr-only">Close</span>
+			</DialogPrimitive.Close>
+		</DialogPrimitive.Content>
+	</DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+	className,
+	...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+	<div
+		className={cn(
+			"flex flex-col space-y-1.5 text-center sm:text-left",
+			className,
+		)}
+		{...props}
+	/>
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({
+	className,
+	...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+	<div
+		className={cn(
+			"flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+			className,
+		)}
+		{...props}
+	/>
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+	React.ElementRef<typeof DialogPrimitive.Title>,
+	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+	<DialogPrimitive.Title
+		ref={ref}
+		className={cn(
+			"text-lg font-semibold leading-none tracking-tight",
+			className,
+		)}
+		{...props}
+	/>
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+	React.ElementRef<typeof DialogPrimitive.Description>,
+	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+	<DialogPrimitive.Description
+		ref={ref}
+		className={cn("text-sm text-muted-foreground", className)}
+		{...props}
+	/>
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+	Dialog,
+	DialogPortal,
+	DialogOverlay,
+	DialogClose,
+	DialogTrigger,
+	DialogContent,
+	DialogHeader,
+	DialogFooter,
+	DialogTitle,
+	DialogDescription,
+};

--- a/src/types/dataset.ts
+++ b/src/types/dataset.ts
@@ -55,3 +55,11 @@ export interface VisionConfig {
 	vision_enabled: boolean;
 	field_mappings: FieldMappings;
 }
+
+export interface DatasetDeleteResponse {
+	dataset_name: string;
+	deleted: boolean;
+	message: string;
+	deleted_files_count?: number;
+	deleted_resources?: string[];
+}

--- a/src/types/inference.ts
+++ b/src/types/inference.ts
@@ -1,0 +1,71 @@
+import type { DatasetMessage } from "./dataset";
+
+// Single inference request/response
+export interface InferenceRequest {
+	adapter_path: string;
+	base_model_id: string;
+	prompt: string;
+}
+
+export interface InferenceResponse {
+	result: string;
+}
+
+// Batch inference request/response
+export interface BatchInferenceRequest {
+	adapter_path: string;
+	base_model_id: string;
+	messages: Array<Array<DatasetMessage>>;
+}
+
+export interface BatchInferenceResponse {
+	results: string[];
+}
+
+// Evaluation request/response (moved from training types)
+export type TaskType =
+	| "conversation"
+	| "qa"
+	| "summarization"
+	| "translation"
+	| "classification"
+	| "general";
+
+export type MetricType =
+	| "rouge"
+	| "bertscore"
+	| "accuracy"
+	| "exact_match"
+	| "bleu"
+	| "meteor"
+	| "recall"
+	| "precision"
+	| "f1";
+
+export interface EvaluationRequest {
+	adapter_path: string;
+	base_model_id: string;
+	dataset_id: string;
+	task_type?: TaskType;
+	metrics?: MetricType[];
+	max_samples?: number;
+	num_sample_results?: number;
+}
+
+export interface SampleResult {
+	prediction: string;
+	reference: string;
+	sample_index: number;
+	input?: Array<DatasetMessage>;
+}
+
+export interface EvaluationResponse {
+	metrics: Record<string, number | Record<string, number>>;
+	num_samples: number;
+	dataset_id: string;
+	samples: SampleResult[];
+}
+
+export interface ApiErrorResponse {
+	error: string;
+}

--- a/src/types/training.ts
+++ b/src/types/training.ts
@@ -1,7 +1,13 @@
+export interface EvaluationMetrics {
+	accuracy?: number;
+	perplexity?: number;
+	eval_loss?: number;
+}
+
 export interface TrainingJob {
 	job_id: string;
 	job_name?: string;
-	status?: string;
+	status?: "queued" | "preparing" | "training" | "completed" | "failed";
 	processed_dataset_id?: string;
 	base_model_id?: string;
 	created_at?: string;
@@ -9,6 +15,7 @@ export interface TrainingJob {
 	adapter_path?: string;
 	error?: string;
 	modality?: "text" | "vision";
+	metrics?: EvaluationMetrics;
 }
 
 export interface BatchInferenceResult {

--- a/src/types/training.ts
+++ b/src/types/training.ts
@@ -27,3 +27,10 @@ export interface BatchInferenceResult {
 export interface InferenceResult {
 	result: string;
 }
+
+export interface JobDeleteResponse {
+	job_id: string;
+	deleted: boolean;
+	message: string;
+	deleted_resources?: string[];
+}

--- a/src/types/training.ts
+++ b/src/types/training.ts
@@ -13,6 +13,7 @@ export interface TrainingJob {
 	created_at?: string;
 	wandb_url?: string;
 	adapter_path?: string;
+	gguf_path?: string;
 	error?: string;
 	modality?: "text" | "vision";
 	metrics?: EvaluationMetrics;

--- a/src/types/training.ts
+++ b/src/types/training.ts
@@ -2,6 +2,7 @@ export interface EvaluationMetrics {
 	accuracy?: number;
 	perplexity?: number;
 	eval_loss?: number;
+	eval_runtime?: number;
 }
 
 export interface TrainingJob {


### PR DESCRIPTION
Frontend changes for eval and export: https://github.com/gemma-fine-tuning/services/pull/29

## Summary

- Training config: new fields and eval related fields (e.g. eval strategy, compute metrics, batch)
- Enhanced job details display to include metrics if available + eval action
- Inference endpoint schema update
- Refactor message display component to handle chatML format messages display
- Evaluations page and api to config and view results of evaluation at inference service
- Deleting jobs and processed datasets
- Downloading GGUF models (currently with public accessible object URL, signed URL doesn't work yet)

> This does not include downloading merged model or adapters yet might come later