### PR TITLE
Frontend support for prompt-only and preference dataset types

### DIFF
--- a/src/app/dashboard/datasets/[datasetName]/page.tsx
+++ b/src/app/dashboard/datasets/[datasetName]/page.tsx
@@ -195,18 +195,124 @@ const DatasetPage = ({
 								<div className="space-y-4">
 									{split.samples.map((sample, index) => (
 										<Card
-											key={`sample-${index}-${sample.messages[0]?.content.slice(0, 20)}`}
+											key={`sample-${index}-${JSON.stringify(sample).slice(0, 20)}`}
 											className="border-dashed"
 										>
 											<CardContent className="">
-												<div className="space-y-3">
-													{sample.messages.map(
-														(message, msgIndex) =>
-															renderMessage(
+												{sample.messages ? (
+													// Language modeling format
+													<div className="space-y-3">
+														{sample.messages.map(
+															(
 																message,
-															),
-													)}
-												</div>
+																msgIndex,
+															) =>
+																renderMessage(
+																	message,
+																),
+														)}
+													</div>
+												) : sample.prompt ? (
+													// Prompt-only or Preference format
+													<div className="space-y-3">
+														<div className="text-sm font-medium text-muted-foreground mb-2">
+															Prompt:
+														</div>
+														{sample.prompt.map(
+															(
+																message,
+																msgIndex,
+															) =>
+																renderMessage(
+																	message,
+																),
+														)}
+
+														{/* Handle preference format (chosen/rejected) */}
+														{sample.chosen &&
+														sample.rejected ? (
+															<div className="space-y-4 mt-4">
+																<div>
+																	<div className="text-sm font-medium text-green-700 mb-2">
+																		Chosen
+																		Response:
+																	</div>
+																	<div className="space-y-2">
+																		{(
+																			sample.chosen as DatasetMessage[]
+																		).map(
+																			(
+																				message: DatasetMessage,
+																				msgIndex: number,
+																			) =>
+																				renderMessage(
+																					message,
+																				),
+																		)}
+																	</div>
+																</div>
+																<div>
+																	<div className="text-sm font-medium text-red-700 mb-2">
+																		Rejected
+																		Response:
+																	</div>
+																	<div className="space-y-2">
+																		{(
+																			sample.rejected as DatasetMessage[]
+																		).map(
+																			(
+																				message: DatasetMessage,
+																				msgIndex: number,
+																			) =>
+																				renderMessage(
+																					message,
+																				),
+																		)}
+																	</div>
+																</div>
+															</div>
+														) : (
+															/* Show additional fields for prompt-only */
+															Object.entries(
+																sample,
+															)
+																.filter(
+																	([key]) =>
+																		key !==
+																		"prompt",
+																)
+																.map(
+																	([
+																		key,
+																		value,
+																	]) => (
+																		<div
+																			key={
+																				key
+																			}
+																			className="mt-3 p-2 bg-muted/50 rounded"
+																		>
+																			<div className="text-sm font-medium text-muted-foreground">
+																				{
+																					key
+																				}
+																				:
+																			</div>
+																			<div className="text-sm">
+																				{String(
+																					value,
+																				)}
+																			</div>
+																		</div>
+																	),
+																)
+														)}
+													</div>
+												) : (
+													<div className="text-sm text-muted-foreground">
+														Unknown sample format
+													</div>
+												)}
 											</CardContent>
 										</Card>
 									))}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -38,7 +38,7 @@ const DatasetsSection = () => {
 				const response = await fetch("/api/datasets");
 				const data = await response.json();
 
-				// We need to map from the API response to our DatasetSample type
+				// We need to map from the API response to our Dataset type
 				const formattedData = data.datasets.map(
 					(dataset: {
 						dataset_name: string;
@@ -109,7 +109,7 @@ const DatasetsSection = () => {
 			) : (
 				<div className="text-center py-12 border-2 border-dashed border-muted-foreground/25 rounded-lg space-y-6">
 					<p className="text-muted-foreground">
-						No jobs yet. Start a training job to see it here.
+						No datasets yet. Add a dataset to get started.
 					</p>
 					<Link
 						href="/dashboard/datasets/selection"

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -1,8 +1,8 @@
 import { atom } from "jotai";
-import type { FieldMappings } from "./types/dataset";
+import type { FieldMappings, UserFieldMapping } from "./types/dataset";
 
 /* ********** Datasets Atoms ********** */
-export type DatasetSample = {
+export type Dataset = {
 	datasetName: string;
 	datasetId: string;
 	processed_dataset_id: string;
@@ -13,7 +13,7 @@ export type DatasetSample = {
 	splits: string[];
 	modality: "text" | "vision";
 };
-export const datasetsAtom = atom<DatasetSample[]>([]);
+export const datasetsAtom = atom<Dataset[]>([]);
 export const datasetsLoadingAtom = atom<boolean>(false);
 /* ********** Datasets Atoms ********** */
 
@@ -66,6 +66,10 @@ export const datasetSelectionAtom = atom<DatasetSelectionType | null>(null);
 
 export const datasetNameAtom = atom<string>("");
 
+// Processing mode
+export type ProcessingMode = "language_modeling" | "prompt_only" | "preference";
+export const processingModeAtom = atom<ProcessingMode>("language_modeling");
+
 export type FieldMappingType = "column" | "template";
 
 export type FieldMapping = {
@@ -82,14 +86,10 @@ export const systemMessageMappingAtom = atom<FieldMapping>({
 	value: "",
 });
 
-// User Message Mapping
-export const userMessageColumnAtom = atom<string>("");
-export const userMessageTemplateAtom = atom<string>("");
-export const userMessageTabAtom = atom<FieldMappingType>("column");
-export const userMessageMappingAtom = atom<FieldMapping>({
-	type: "column",
-	value: "",
-});
+// New user field list structure
+export const userFieldListAtom = atom<UserFieldMapping[]>([
+	{ type: "template", value: "" },
+]);
 
 // Assistant Message Mapping
 export const assistantMessageColumnAtom = atom<string>("");
@@ -100,9 +100,30 @@ export const assistantMessageMappingAtom = atom<FieldMapping>({
 	value: "",
 });
 
+// Chosen Field Mapping (for preference mode)
+export const chosenFieldColumnAtom = atom<string>("");
+export const chosenFieldTemplateAtom = atom<string>("");
+export const chosenFieldTabAtom = atom<FieldMappingType>("column");
+export const chosenFieldMappingAtom = atom<FieldMapping>({
+	type: "column",
+	value: "",
+});
+
+// Rejected Field Mapping (for preference mode)
+export const rejectedFieldColumnAtom = atom<string>("");
+export const rejectedFieldTemplateAtom = atom<string>("");
+export const rejectedFieldTabAtom = atom<FieldMappingType>("column");
+export const rejectedFieldMappingAtom = atom<FieldMapping>({
+	type: "column",
+	value: "",
+});
+
 // Vision Field Mapping
 export const visionEnabledAtom = atom<boolean>(false);
 export const visionFieldMappingAtom = atom<FieldMappings>({});
+
+// Additional Field Mappings (for prompt-only mode)
+export const additionalFieldMappingsAtom = atom<FieldMappings>({});
 
 // Split Settings
 export const splitTypeAtom = atom<"hf_split" | "manual_split" | "no_split">(

--- a/src/components/additional-field-mapping.tsx
+++ b/src/components/additional-field-mapping.tsx
@@ -1,0 +1,226 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import type { FieldMappings } from "@/types/dataset";
+import { PlusIcon, TrashIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+
+interface AdditionalFieldMappingProps {
+	columns: string[];
+	value: FieldMappings;
+	onChange: (value: FieldMappings) => void;
+	excludeColumns?: string[];
+}
+
+const AdditionalFieldMapping = ({
+	columns,
+	value,
+	onChange,
+	excludeColumns = [],
+}: AdditionalFieldMappingProps) => {
+	const availableColumns = columns.filter(
+		col => !excludeColumns.includes(col),
+	);
+
+	// Track display names separately to avoid re-rendering issues
+	const [displayNames, setDisplayNames] = useState<Record<string, string>>(
+		{},
+	);
+
+	// Initialize display names when value changes
+	useEffect(() => {
+		const newDisplayNames: Record<string, string> = {};
+		for (const key of Object.keys(value)) {
+			if (!displayNames[key]) {
+				newDisplayNames[key] = key.startsWith("additional_field_")
+					? key.replace("additional_field_", "")
+					: key;
+			} else {
+				newDisplayNames[key] = displayNames[key];
+			}
+		}
+		setDisplayNames(newDisplayNames);
+	}, [value, displayNames]);
+
+	const handleAddMapping = () => {
+		const newKey = `additional_field_${Object.keys(value).length + 1}`;
+		onChange({ ...value, [newKey]: { type: "column", value: "" } });
+	};
+
+	const handleRemoveMapping = (key: string) => {
+		const newValue = { ...value };
+		delete newValue[key];
+		onChange(newValue);
+
+		// Also remove from display names
+		const newDisplayNames = { ...displayNames };
+		delete newDisplayNames[key];
+		setDisplayNames(newDisplayNames);
+	};
+
+	const handleFieldNameChange = (oldKey: string, newFieldName: string) => {
+		// Only update the key if the field name is not empty and different from the old key
+		if (newFieldName && newFieldName !== oldKey) {
+			const newValue = { ...value };
+			const mapping = newValue[oldKey];
+			delete newValue[oldKey];
+			newValue[newFieldName] = mapping;
+			onChange(newValue);
+
+			// Update display names
+			const newDisplayNames = { ...displayNames };
+			delete newDisplayNames[oldKey];
+			newDisplayNames[newFieldName] = newFieldName;
+			setDisplayNames(newDisplayNames);
+		}
+	};
+
+	const handleDisplayNameChange = (key: string, displayName: string) => {
+		setDisplayNames(prev => ({ ...prev, [key]: displayName }));
+	};
+
+	const handleColumnChange = (key: string, newColumn: string) => {
+		onChange({ ...value, [key]: { ...value[key], value: newColumn } });
+	};
+
+	const handleTypeChange = (key: string, newType: "column" | "template") => {
+		onChange({
+			...value,
+			[key]: { ...value[key], type: newType, value: "" },
+		});
+	};
+
+	const handleTemplateChange = (key: string, newTemplate: string) => {
+		onChange({ ...value, [key]: { ...value[key], value: newTemplate } });
+	};
+
+	return (
+		<div className="space-y-4">
+			{Object.entries(value).map(([key, mapping]) => (
+				<div
+					key={key}
+					className="flex flex-col gap-3 p-3 border rounded-lg"
+				>
+					<div className="flex items-end gap-2">
+						<div className="flex-grow space-y-2">
+							<Label htmlFor={`${key}-name`}>Field Name</Label>
+							<Input
+								id={`${key}-name`}
+								value={displayNames[key] || ""}
+								onChange={e =>
+									handleDisplayNameChange(key, e.target.value)
+								}
+								onBlur={e => {
+									const newName =
+										e.target.value.trim() ||
+										`additional_field_${Date.now()}`;
+									if (newName !== key) {
+										handleFieldNameChange(key, newName);
+									}
+								}}
+								placeholder="Enter field name (e.g., answer, reasoning)"
+							/>
+						</div>
+						<Button
+							variant="destructive"
+							size="icon"
+							onClick={() => handleRemoveMapping(key)}
+							type="button"
+						>
+							<TrashIcon className="h-4 w-4" />
+						</Button>
+					</div>
+
+					<Tabs
+						value={mapping.type}
+						onValueChange={newType =>
+							handleTypeChange(
+								key,
+								newType as "column" | "template",
+							)
+						}
+					>
+						<TabsList className="grid w-full grid-cols-2">
+							<TabsTrigger value="column">Column</TabsTrigger>
+							<TabsTrigger value="template">Template</TabsTrigger>
+						</TabsList>
+
+						<TabsContent value="column" className="space-y-2">
+							<Label htmlFor={`${key}-column`}>
+								Source Column
+							</Label>
+							<Select
+								value={
+									mapping.type === "column"
+										? mapping.value
+										: ""
+								}
+								onValueChange={newColumn =>
+									handleColumnChange(key, newColumn)
+								}
+							>
+								<SelectTrigger id={`${key}-column`}>
+									<SelectValue placeholder="Select a column" />
+								</SelectTrigger>
+								<SelectContent>
+									{availableColumns.map(column => (
+										<SelectItem key={column} value={column}>
+											{column}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</TabsContent>
+
+						<TabsContent value="template" className="space-y-2">
+							<Label htmlFor={`${key}-template`}>Template</Label>
+							<Textarea
+								id={`${key}-template`}
+								value={
+									mapping.type === "template"
+										? mapping.value
+										: ""
+								}
+								onChange={e =>
+									handleTemplateChange(key, e.target.value)
+								}
+								placeholder="Enter a template for this field"
+								rows={3}
+							/>
+						</TabsContent>
+					</Tabs>
+				</div>
+			))}
+
+			<Button
+				onClick={handleAddMapping}
+				className="w-full"
+				variant="outline"
+				type="button"
+			>
+				<PlusIcon className="h-4 w-4 mr-2" />
+				Add Additional Field
+			</Button>
+
+			{availableColumns.length === 0 &&
+				Object.keys(value).length === 0 && (
+					<div className="text-sm text-muted-foreground text-center p-4 bg-muted/50 rounded">
+						All available columns are already mapped.
+						{excludeColumns.length > 0 &&
+							" System and user fields are excluded."}
+					</div>
+				)}
+		</div>
+	);
+};
+
+export default AdditionalFieldMapping;

--- a/src/components/dataset-card.tsx
+++ b/src/components/dataset-card.tsx
@@ -1,4 +1,4 @@
-import type { DatasetSample } from "@/atoms";
+import type { Dataset } from "@/atoms";
 import { FileTextIcon, ImageIcon } from "lucide-react";
 import Link from "next/link";
 import {
@@ -9,7 +9,7 @@ import {
 	CardTitle,
 } from "./ui/card";
 
-const DatasetCard = ({ dataset }: { dataset: DatasetSample }) => {
+const DatasetCard = ({ dataset }: { dataset: Dataset }) => {
 	const ModalityIcon =
 		dataset.modality === "vision" ? ImageIcon : FileTextIcon;
 	return (

--- a/src/components/field-mapping-section.tsx
+++ b/src/components/field-mapping-section.tsx
@@ -1,0 +1,264 @@
+import type { FieldMappingType, ProcessingMode } from "@/atoms";
+import AdditionalFieldMapping from "@/components/additional-field-mapping";
+import FieldMapping from "@/components/field-mapping";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import UserFieldMappingComponent from "@/components/user-field-mapping";
+import { cn } from "@/lib/utils";
+import type { FieldMappings, UserFieldMapping } from "@/types/dataset";
+
+interface FieldMappingSectionProps {
+	processingMode: ProcessingMode;
+	columns: string[];
+
+	// System message
+	systemMessageColumn: string;
+	setSystemMessageColumn: (value: string) => void;
+	systemMessageTemplate: string;
+	setSystemMessageTemplate: (value: string) => void;
+	systemMessageTab: FieldMappingType;
+	setSystemMessageTab: (value: FieldMappingType) => void;
+
+	// User field list (new structure)
+	userFieldList: UserFieldMapping[];
+	setUserFieldList: (value: UserFieldMapping[]) => void;
+
+	// Assistant message (only for language modeling)
+	assistantMessageColumn: string;
+	setAssistantMessageColumn: (value: string) => void;
+	assistantMessageTemplate: string;
+	setAssistantMessageTemplate: (value: string) => void;
+	assistantMessageTab: FieldMappingType;
+	setAssistantMessageTab: (value: FieldMappingType) => void;
+
+	// Chosen field (only for preference mode)
+	chosenFieldColumn: string;
+	setChosenFieldColumn: (value: string) => void;
+	chosenFieldTemplate: string;
+	setChosenFieldTemplate: (value: string) => void;
+	chosenFieldTab: FieldMappingType;
+	setChosenFieldTab: (value: FieldMappingType) => void;
+
+	// Rejected field (only for preference mode)
+	rejectedFieldColumn: string;
+	setRejectedFieldColumn: (value: string) => void;
+	rejectedFieldTemplate: string;
+	setRejectedFieldTemplate: (value: string) => void;
+	rejectedFieldTab: FieldMappingType;
+	setRejectedFieldTab: (value: FieldMappingType) => void;
+
+	// Additional fields (for prompt-only)
+	additionalFieldMappings: FieldMappings;
+	setAdditionalFieldMappings: (value: FieldMappings) => void;
+}
+
+const FieldMappingSection = ({
+	processingMode,
+	columns,
+	systemMessageColumn,
+	setSystemMessageColumn,
+	systemMessageTemplate,
+	setSystemMessageTemplate,
+	systemMessageTab,
+	setSystemMessageTab,
+	userFieldList,
+	setUserFieldList,
+	assistantMessageColumn,
+	setAssistantMessageColumn,
+	assistantMessageTemplate,
+	setAssistantMessageTemplate,
+	assistantMessageTab,
+	setAssistantMessageTab,
+	chosenFieldColumn,
+	setChosenFieldColumn,
+	chosenFieldTemplate,
+	setChosenFieldTemplate,
+	chosenFieldTab,
+	setChosenFieldTab,
+	rejectedFieldColumn,
+	setRejectedFieldColumn,
+	rejectedFieldTemplate,
+	setRejectedFieldTemplate,
+	rejectedFieldTab,
+	setRejectedFieldTab,
+	additionalFieldMappings,
+	setAdditionalFieldMappings,
+}: FieldMappingSectionProps) => {
+	const getExcludedColumns = () => {
+		const excluded = [];
+		if (systemMessageTab === "column" && systemMessageColumn) {
+			excluded.push(systemMessageColumn);
+		}
+		// Add user field columns
+		for (const field of userFieldList) {
+			if (field.type === "column" && field.value) {
+				excluded.push(field.value);
+			}
+		}
+		if (
+			processingMode === "language_modeling" &&
+			assistantMessageTab === "column" &&
+			assistantMessageColumn
+		) {
+			excluded.push(assistantMessageColumn);
+		}
+		if (processingMode === "preference") {
+			if (chosenFieldTab === "column" && chosenFieldColumn) {
+				excluded.push(chosenFieldColumn);
+			}
+			if (rejectedFieldTab === "column" && rejectedFieldColumn) {
+				excluded.push(rejectedFieldColumn);
+			}
+		}
+		return excluded;
+	};
+
+	return (
+		<>
+			{/* Main Field Mappings */}
+			<Card>
+				<CardHeader className="border-b border-input">
+					<CardTitle>Fields Mapping</CardTitle>
+					<CardDescription>
+						Map the required fields with the dataset columns.
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="border-b border-input">
+					<h2 className="font-semibold mb-2">System Message</h2>
+					<p className="text-sm text-muted-foreground mb-4">
+						Map the system message with the dataset columns.
+					</p>
+					<FieldMapping
+						columnValue={systemMessageColumn}
+						setColumnValue={setSystemMessageColumn}
+						templateValue={systemMessageTemplate}
+						setTemplateValue={setSystemMessageTemplate}
+						tabValue={systemMessageTab}
+						setTabValue={setSystemMessageTab}
+						columns={columns}
+						forMessage="system"
+					/>
+				</CardContent>
+				<CardContent
+					className={cn(
+						"border-input",
+						(processingMode === "language_modeling" ||
+							processingMode === "preference") &&
+							"border-b",
+						processingMode === "prompt_only" && "border-b-0",
+					)}
+				>
+					<h2 className="font-semibold mb-2">User Message</h2>
+					<p className="text-sm text-muted-foreground mb-4">
+						Configure the user message content. You can combine text
+						templates, column data, and images.
+					</p>
+					<UserFieldMappingComponent
+						columns={columns}
+						value={userFieldList}
+						onChange={setUserFieldList}
+						excludeColumns={getExcludedColumns()}
+					/>
+				</CardContent>
+				{processingMode === "language_modeling" && (
+					<CardContent className="border-b-0">
+						<h2 className="font-semibold mb-2">
+							Assistant Message
+						</h2>
+						<p className="text-sm text-muted-foreground mb-4">
+							Map the assistant message with the dataset columns.
+						</p>
+						<FieldMapping
+							columnValue={assistantMessageColumn}
+							setColumnValue={setAssistantMessageColumn}
+							templateValue={assistantMessageTemplate}
+							setTemplateValue={setAssistantMessageTemplate}
+							tabValue={assistantMessageTab}
+							setTabValue={setAssistantMessageTab}
+							columns={columns}
+							forMessage="assistant"
+						/>
+					</CardContent>
+				)}
+
+				{processingMode === "preference" && (
+					<>
+						<CardContent className="border-b border-input">
+							<h2 className="font-semibold mb-2">
+								Chosen Response
+							</h2>
+							<p className="text-sm text-muted-foreground mb-4">
+								Map the preferred/chosen response with the
+								dataset columns.
+							</p>
+							<FieldMapping
+								columnValue={chosenFieldColumn}
+								setColumnValue={setChosenFieldColumn}
+								templateValue={chosenFieldTemplate}
+								setTemplateValue={setChosenFieldTemplate}
+								tabValue={chosenFieldTab}
+								setTabValue={setChosenFieldTab}
+								columns={columns}
+								forMessage="assistant"
+							/>
+						</CardContent>
+						<CardContent className="border-b-0">
+							<h2 className="font-semibold mb-2">
+								Rejected Response
+							</h2>
+							<p className="text-sm text-muted-foreground mb-4">
+								Map the rejected/dispreferred response with the
+								dataset columns.
+							</p>
+							<FieldMapping
+								columnValue={rejectedFieldColumn}
+								setColumnValue={setRejectedFieldColumn}
+								templateValue={rejectedFieldTemplate}
+								setTemplateValue={setRejectedFieldTemplate}
+								tabValue={rejectedFieldTab}
+								setTabValue={setRejectedFieldTab}
+								columns={columns}
+								forMessage="assistant"
+							/>
+						</CardContent>
+					</>
+				)}
+			</Card>
+
+			{/* Additional Fields for Prompt-Only Mode */}
+			{processingMode === "prompt_only" && (
+				<Card>
+					<CardHeader className="border-b border-input">
+						<CardTitle>Additional Fields</CardTitle>
+						<CardDescription>
+							Map additional fields that will be included as
+							separate string columns in the output.
+						</CardDescription>
+					</CardHeader>
+					<CardContent className="space-y-4">
+						<div className="text-sm text-muted-foreground">
+							In prompt-only mode, you can map additional columns
+							from your dataset as separate fields. These are
+							commonly used for labels, answers, reasoning, or any
+							other metadata you want to include.
+						</div>
+						<AdditionalFieldMapping
+							columns={columns}
+							value={additionalFieldMappings}
+							onChange={setAdditionalFieldMappings}
+							excludeColumns={getExcludedColumns()}
+						/>
+					</CardContent>
+				</Card>
+			)}
+		</>
+	);
+};
+
+export default FieldMappingSection;

--- a/src/components/processing-mode-selector.tsx
+++ b/src/components/processing-mode-selector.tsx
@@ -1,0 +1,79 @@
+import type { ProcessingMode } from "@/atoms";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { RadioCardGroup, RadioCardGroupItem } from "@/components/ui/radio-card";
+
+interface ProcessingModeSelectorProps {
+	value: ProcessingMode;
+	onChange: (value: ProcessingMode) => void;
+}
+
+const processingModeOptions = [
+	{
+		value: "language_modeling" as const,
+		title: "Language Modeling",
+		description:
+			"Standard conversational format for supervised fine-tuning. Maps your data to assistant responses for the model to learn from.",
+	},
+	{
+		value: "prompt_only" as const,
+		title: "Prompt-Only",
+		description:
+			"For policy optimization like GRPO. Only provides prompts, the model generates its own responses during training.",
+	},
+	{
+		value: "preference" as const,
+		title: "Preference",
+		description:
+			"For preference learning like DPO/RLHF. Includes chosen and rejected responses for the model to learn preferences.",
+	},
+];
+
+const ProcessingModeSelector = ({
+	value,
+	onChange,
+}: ProcessingModeSelectorProps) => {
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Processing Mode</CardTitle>
+				<CardDescription>
+					Choose how your dataset should be processed for fine-tuning.
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<RadioCardGroup
+					value={value}
+					onValueChange={newValue =>
+						onChange(newValue as ProcessingMode)
+					}
+					className="grid w-full grid-cols-1 gap-4 md:grid-cols-2"
+				>
+					{processingModeOptions.map(option => (
+						<RadioCardGroupItem
+							key={option.value}
+							value={option.value}
+							className="cursor-pointer"
+						>
+							<div className="flex flex-col space-y-2">
+								<div className="text-sm font-medium">
+									{option.title}
+								</div>
+								<div className="text-xs text-muted-foreground">
+									{option.description}
+								</div>
+							</div>
+						</RadioCardGroupItem>
+					))}
+				</RadioCardGroup>
+			</CardContent>
+		</Card>
+	);
+};
+
+export default ProcessingModeSelector;

--- a/src/components/user-field-mapping.tsx
+++ b/src/components/user-field-mapping.tsx
@@ -1,0 +1,173 @@
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import type { UserFieldMapping } from "@/types/dataset";
+import { PlusIcon, TrashIcon } from "lucide-react";
+
+interface UserFieldMappingProps {
+	columns: string[];
+	value: UserFieldMapping[];
+	onChange: (value: UserFieldMapping[]) => void;
+	excludeColumns?: string[];
+}
+
+const UserFieldMappingComponent = ({
+	columns,
+	value,
+	onChange,
+	excludeColumns = [],
+}: UserFieldMappingProps) => {
+	const availableColumns = columns.filter(
+		col => !excludeColumns.includes(col),
+	);
+
+	const handleAddField = () => {
+		onChange([...value, { type: "template", value: "" }]);
+	};
+
+	const handleRemoveField = (index: number) => {
+		const newValue = value.filter((_, i) => i !== index);
+		onChange(newValue);
+	};
+
+	const handleFieldChange = (index: number, field: UserFieldMapping) => {
+		const newValue = [...value];
+		newValue[index] = field;
+		onChange(newValue);
+	};
+
+	const handleTypeChange = (
+		index: number,
+		type: "template" | "column" | "image",
+	) => {
+		const newField = { ...value[index], type, value: "" };
+		handleFieldChange(index, newField);
+	};
+
+	const handleValueChange = (index: number, newValue: string) => {
+		const newField = { ...value[index], value: newValue };
+		handleFieldChange(index, newField);
+	};
+
+	return (
+		<div className="space-y-4">
+			{value.map((field, index) => (
+				<div
+					key={`field-${index}-${field.type}-${field.value}`}
+					className="flex flex-col gap-3 p-3 border rounded-lg"
+				>
+					<div className="flex items-center justify-between">
+						<Label>Content Part {index + 1}</Label>
+						{value.length > 1 && (
+							<Button
+								variant="destructive"
+								size="sm"
+								onClick={() => handleRemoveField(index)}
+								type="button"
+							>
+								<TrashIcon className="h-4 w-4" />
+							</Button>
+						)}
+					</div>
+
+					<Tabs
+						value={field.type}
+						onValueChange={newType =>
+							handleTypeChange(
+								index,
+								newType as "template" | "column" | "image",
+							)
+						}
+					>
+						<TabsList className="grid w-full grid-cols-3">
+							<TabsTrigger value="template">Template</TabsTrigger>
+							<TabsTrigger value="column">Column</TabsTrigger>
+							<TabsTrigger value="image">Image</TabsTrigger>
+						</TabsList>
+
+						<TabsContent value="template" className="space-y-2">
+							<Label htmlFor={`template-${index}`}>
+								Template Text
+							</Label>
+							<Textarea
+								id={`template-${index}`}
+								value={field.value || ""}
+								onChange={e =>
+									handleValueChange(index, e.target.value)
+								}
+								placeholder="Enter template text for user message"
+								rows={3}
+							/>
+						</TabsContent>
+
+						<TabsContent value="column" className="space-y-2">
+							<Label htmlFor={`column-${index}`}>
+								Source Column
+							</Label>
+							<Select
+								value={field.value || ""}
+								onValueChange={newValue =>
+									handleValueChange(index, newValue)
+								}
+							>
+								<SelectTrigger id={`column-${index}`}>
+									<SelectValue placeholder="Select a column" />
+								</SelectTrigger>
+								<SelectContent>
+									{availableColumns.map(column => (
+										<SelectItem key={column} value={column}>
+											{column}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</TabsContent>
+
+						<TabsContent value="image" className="space-y-2">
+							<Label htmlFor={`image-${index}`}>
+								Image Column
+							</Label>
+							<Select
+								value={field.value || ""}
+								onValueChange={newValue =>
+									handleValueChange(index, newValue)
+								}
+							>
+								<SelectTrigger id={`image-${index}`}>
+									<SelectValue placeholder="Select an image column" />
+								</SelectTrigger>
+								<SelectContent>
+									{availableColumns.map(column => (
+										<SelectItem key={column} value={column}>
+											{column}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</TabsContent>
+					</Tabs>
+				</div>
+			))}
+
+			<Button
+				onClick={handleAddField}
+				className="w-full"
+				variant="outline"
+				type="button"
+			>
+				<PlusIcon className="h-4 w-4 mr-2" />
+				Add Content Part
+			</Button>
+		</div>
+	);
+};
+
+export default UserFieldMappingComponent;

--- a/src/types/dataset.ts
+++ b/src/types/dataset.ts
@@ -16,9 +16,14 @@ export interface DatasetMessage {
 }
 
 export interface DatasetSample {
-	messages: DatasetMessage[];
+	messages?: DatasetMessage[];
+	// For prompt-only mode
+	prompt?: DatasetMessage[];
+	// For preference mode
+	chosen?: DatasetMessage[];
+	rejected?: DatasetMessage[];
+	[key: string]: unknown; // Additional dynamic fields based on user field mappings (strings only)
 }
-
 export interface DatasetSplit {
 	split_name: string;
 	num_rows: number;
@@ -44,6 +49,11 @@ export interface DatasetDetailState {
 }
 
 export interface FieldMapping {
+	type: "template" | "column" | "image";
+	value: string;
+}
+
+export interface UserFieldMapping extends FieldMapping {
 	type: "template" | "column" | "image";
 	value: string;
 }


### PR DESCRIPTION
This complements backend PR https://github.com/gemma-fine-tuning/services/pull/39, will also close #9 

## Summary

- Conditionally set the configuration page based on preprocessing mode
- New field mapping (and substitute components such as user messages) refactored to support language modelling, prompt-only, and preference datasets since they require different fields
- Generally replace all user messages with new list based approach as mandated in backend issue
- Updates types, atoms, previewer (just parsing structure), API endpoints with minor changes

## Note

This might have created a lot of technical debt since I'm trying to ship frontend asap... We can always patch these since the backend is very solid.