### PR TITLE
[FEATURE] Implement response caching for jobs and datasets

### DIFF
--- a/src/app/dashboard/datasets/configuration/page.tsx
+++ b/src/app/dashboard/datasets/configuration/page.tsx
@@ -481,7 +481,10 @@ const DatasetConfiguration = () => {
 				};
 
 				// Add the new dataset to the existing list
-				setDatasets(prevDatasets => [...prevDatasets, newDataset]);
+				setDatasets({
+					...datasets,
+					datasets: [...datasets.datasets, newDataset],
+				});
 			}
 
 			toast.success("Dataset processed successfully.");

--- a/src/app/dashboard/datasets/page.tsx
+++ b/src/app/dashboard/datasets/page.tsx
@@ -1,60 +1,14 @@
 "use client";
 
-import { datasetsAtom, datasetsLoadingAtom } from "@/atoms";
 import DatasetCard from "@/components/dataset-card";
 import { buttonVariants } from "@/components/ui/button";
+import { useDatasets } from "@/hooks/useDatasets";
 import { cn } from "@/lib/utils";
-import { useAtom } from "jotai";
 import { Loader2, PlusIcon } from "lucide-react";
 import Link from "next/link";
-import { useEffect } from "react";
 
 const Datasets = () => {
-	const [datasets, setDatasets] = useAtom(datasetsAtom);
-	const [isLoading, setIsLoading] = useAtom(datasetsLoadingAtom);
-
-	useEffect(() => {
-		const fetchDatasets = async () => {
-			setIsLoading(true);
-			try {
-				const response = await fetch("/api/datasets");
-				const data = await response.json();
-
-				const formattedData = data.datasets.map(
-					(dataset: {
-						dataset_name: string;
-						dataset_id: string;
-						processed_dataset_id: string;
-						dataset_source: "upload" | "huggingface";
-						dataset_subset: string;
-						num_examples: number;
-						created_at: string;
-						splits: string[];
-						modality: "text" | "vision";
-					}) => ({
-						datasetName: dataset.dataset_name,
-						datasetId: dataset.dataset_id,
-						processed_dataset_id: dataset.processed_dataset_id,
-						datasetSource:
-							dataset.dataset_source === "upload"
-								? "local"
-								: "huggingface",
-						datasetSubset: dataset.dataset_subset,
-						numExamples: dataset.num_examples,
-						createdAt: dataset.created_at,
-						splits: dataset.splits,
-						modality: dataset.modality,
-					}),
-				);
-				setDatasets(formattedData);
-			} catch (error) {
-				console.error("Failed to fetch datasets:", error);
-			} finally {
-				setIsLoading(false);
-			}
-		};
-		fetchDatasets();
-	}, [setDatasets, setIsLoading]);
+	const { datasets, loading, error } = useDatasets();
 
 	return (
 		<div>
@@ -68,7 +22,7 @@ const Datasets = () => {
 					Add Dataset
 				</Link>
 			</div>
-			{isLoading ? (
+			{loading ? (
 				<div className="flex items-center justify-center py-12">
 					<div className="flex flex-col items-center gap-4">
 						<Loader2 className="w-8 h-8 animate-spin" />
@@ -77,7 +31,17 @@ const Datasets = () => {
 						</p>
 					</div>
 				</div>
-			) : (
+			) : error ? (
+				<div className="text-center py-12 border-2 border-dashed border-muted-foreground/25 rounded-lg space-y-6">
+					<p className="text-muted-foreground">{error}</p>
+				</div>
+			) : datasets.length === 0 ? (
+				<div className="text-center py-12 border-2 border-dashed border-muted-foreground/25 rounded-lg space-y-6">
+					<p className="text-muted-foreground">
+						No datasets yet. Add a dataset to get started.
+					</p>
+				</div>
+			) : datasets.length > 0 ? (
 				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
 					{datasets.map(dataset => (
 						<DatasetCard
@@ -86,7 +50,7 @@ const Datasets = () => {
 						/>
 					))}
 				</div>
-			)}
+			) : null}
 		</div>
 	);
 };

--- a/src/app/dashboard/datasets/page.tsx
+++ b/src/app/dashboard/datasets/page.tsx
@@ -1,26 +1,37 @@
 "use client";
 
 import DatasetCard from "@/components/dataset-card";
-import { buttonVariants } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { useDatasets } from "@/hooks/useDatasets";
 import { cn } from "@/lib/utils";
-import { Loader2, PlusIcon } from "lucide-react";
+import { Loader2, PlusIcon, RefreshCcw } from "lucide-react";
 import Link from "next/link";
 
 const Datasets = () => {
-	const { datasets, loading, error } = useDatasets();
+	const { datasets, loading, error, refresh } = useDatasets();
 
 	return (
 		<div>
 			<div className="flex items-center justify-between">
 				<h1 className="text-2xl font-bold">All Datasets</h1>
-				<Link
-					href="/dashboard/datasets/selection"
-					className={cn(buttonVariants({ variant: "outline" }))}
-				>
-					<PlusIcon className="w-4 h-4" />
-					Add Dataset
-				</Link>
+				<div className="flex items-center gap-2">
+					<Button
+						variant="outline"
+						onClick={() => refresh()}
+						disabled={loading}
+						className="cursor-pointer"
+					>
+						<RefreshCcw className={cn(loading && "animate-spin")} />
+						Refresh
+					</Button>
+					<Link
+						href="/dashboard/datasets/selection"
+						className={cn(buttonVariants({ variant: "outline" }))}
+					>
+						<PlusIcon className="w-4 h-4" />
+						Add Dataset
+					</Link>
+				</div>
 			</div>
 			{loading ? (
 				<div className="flex items-center justify-center py-12">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,11 +4,10 @@ import DatasetCard from "@/components/dataset-card";
 import TrainingJobCard from "@/components/training-job-card";
 import { buttonVariants } from "@/components/ui/button";
 import { useDatasets } from "@/hooks/useDatasets";
+import { useTrainingJobs } from "@/hooks/useTrainingJobs";
 import { cn } from "@/lib/utils";
-import type { TrainingJob } from "@/types/training";
 import { Loader2, PlusIcon } from "lucide-react";
 import Link from "next/link";
-import { useEffect, useState } from "react";
 
 const Dashboard = () => {
 	return (
@@ -82,24 +81,7 @@ const DatasetsSection = () => {
 };
 
 const TrainingJobsSection = () => {
-	const [jobs, setJobs] = useState<TrainingJob[]>([]);
-	const [loading, setLoading] = useState(true);
-
-	useEffect(() => {
-		const fetchJobs = async () => {
-			setLoading(true);
-			try {
-				const res = await fetch("/api/jobs");
-				const data = await res.json();
-				setJobs(data.jobs || []);
-			} catch {
-				setJobs([]);
-			} finally {
-				setLoading(false);
-			}
-		};
-		fetchJobs();
-	}, []);
+	const { jobs, loading, error } = useTrainingJobs();
 
 	const recentJobs = jobs.slice(0, 3);
 
@@ -120,6 +102,10 @@ const TrainingJobsSection = () => {
 						<Loader2 className="w-8 h-8 animate-spin" />
 						<p className="text-muted-foreground">Loading jobs...</p>
 					</div>
+				</div>
+			) : error ? (
+				<div className="text-center py-12 border-2 border-dashed border-muted-foreground/25 rounded-lg space-y-6">
+					<p className="text-muted-foreground">{error}</p>
 				</div>
 			) : recentJobs.length > 0 ? (
 				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,11 +2,11 @@
 
 import DatasetCard from "@/components/dataset-card";
 import TrainingJobCard from "@/components/training-job-card";
-import { buttonVariants } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { useDatasets } from "@/hooks/useDatasets";
 import { useTrainingJobs } from "@/hooks/useTrainingJobs";
 import { cn } from "@/lib/utils";
-import { Loader2, PlusIcon } from "lucide-react";
+import { Loader2, PlusIcon, RefreshCcw } from "lucide-react";
 import Link from "next/link";
 
 const Dashboard = () => {
@@ -25,7 +25,7 @@ const Dashboard = () => {
 };
 
 const DatasetsSection = () => {
-	const { datasets, loading, error } = useDatasets();
+	const { datasets, loading, error, refresh } = useDatasets();
 
 	const recentDatasets = datasets.slice(0, 3);
 
@@ -33,12 +33,23 @@ const DatasetsSection = () => {
 		<div className="p-6 space-y-4">
 			<div className="flex items-center justify-between">
 				<h2 className="text-xl font-semibold">Recent Datasets</h2>
-				<Link
-					href="/dashboard/datasets"
-					className={cn(buttonVariants({ variant: "outline" }))}
-				>
-					All Datasets
-				</Link>
+				<div className="flex items-center gap-2">
+					<Button
+						variant="outline"
+						onClick={() => refresh()}
+						disabled={loading}
+						className="cursor-pointer"
+					>
+						<RefreshCcw className={cn(loading && "animate-spin")} />
+						Refresh
+					</Button>
+					<Link
+						href="/dashboard/datasets"
+						className={cn(buttonVariants({ variant: "outline" }))}
+					>
+						All Datasets
+					</Link>
+				</div>
 			</div>
 			{loading ? (
 				<div className="flex items-center justify-center py-12">
@@ -81,7 +92,7 @@ const DatasetsSection = () => {
 };
 
 const TrainingJobsSection = () => {
-	const { jobs, loading, error } = useTrainingJobs();
+	const { jobs, loading, error, refresh } = useTrainingJobs();
 
 	const recentJobs = jobs.slice(0, 3);
 
@@ -89,12 +100,23 @@ const TrainingJobsSection = () => {
 		<div className="p-6 space-y-4">
 			<div className="flex items-center justify-between">
 				<h2 className="text-xl font-semibold">Recent Training Jobs</h2>
-				<Link
-					href="/dashboard/training"
-					className={cn(buttonVariants({ variant: "outline" }))}
-				>
-					All Jobs
-				</Link>
+				<div className="flex items-center gap-2">
+					<Button
+						variant="outline"
+						onClick={() => refresh()}
+						disabled={loading}
+						className="cursor-pointer"
+					>
+						<RefreshCcw className={cn(loading && "animate-spin")} />
+						Refresh
+					</Button>
+					<Link
+						href="/dashboard/training"
+						className={cn(buttonVariants({ variant: "outline" }))}
+					>
+						All Jobs
+					</Link>
+				</div>
 			</div>
 			{loading ? (
 				<div className="flex items-center justify-center py-12">

--- a/src/app/dashboard/training/[jobId]/page.tsx
+++ b/src/app/dashboard/training/[jobId]/page.tsx
@@ -525,7 +525,7 @@ export default function JobDetailPage() {
 							)}
 							{job.error && (
 								<div>
-									<span className="text-sm font-medium text-muted-foreground text-red-600">
+									<span className="text-sm font-medium text-red-600">
 										Error
 									</span>
 									<div className="text-sm text-red-600 bg-red-50 px-2 py-1 rounded mt-1 border border-red-200">

--- a/src/app/dashboard/training/new/dataset/page.tsx
+++ b/src/app/dashboard/training/new/dataset/page.tsx
@@ -5,12 +5,12 @@ import {
 	trainingDatasetModalityAtom,
 	trainingModelAtom,
 } from "@/atoms";
-import { datasetsAtom, datasetsLoadingAtom } from "@/atoms";
 import { Button } from "@/components/ui/button";
 import { CardDescription } from "@/components/ui/card";
 import { RadioCardGroup, RadioCardGroupItem } from "@/components/ui/radio-card";
+import { useDatasets } from "@/hooks/useDatasets";
 import { useAtom } from "jotai";
-import { FileTextIcon, ImageIcon } from "lucide-react";
+import { FileTextIcon, ImageIcon, Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { toast } from "sonner";
@@ -19,8 +19,7 @@ export default function DatasetSelectionPage() {
 	const [datasetId, setDatasetId] = useAtom(trainingDatasetIdAtom);
 	const [_, setModality] = useAtom(trainingDatasetModalityAtom);
 	const [model] = useAtom(trainingModelAtom);
-	const [datasets] = useAtom(datasetsAtom);
-	const [isLoading] = useAtom(datasetsLoadingAtom);
+	const { datasets, loading, error } = useDatasets();
 	const router = useRouter();
 
 	useEffect(() => {
@@ -46,9 +45,24 @@ export default function DatasetSelectionPage() {
 					you have created earlier.
 				</CardDescription>
 			</div>
-			{isLoading ? (
+			{loading ? (
 				<div className="flex items-center justify-center py-8">
-					Loading datasets...
+					<div className="flex flex-col items-center gap-4">
+						<Loader2 className="w-8 h-8 animate-spin" />
+						<p className="text-muted-foreground">
+							Loading datasets...
+						</p>
+					</div>
+				</div>
+			) : error ? (
+				<div className="text-center py-12 border-2 border-dashed border-muted-foreground/25 rounded-lg space-y-6">
+					<p className="text-muted-foreground">{error}</p>
+				</div>
+			) : datasets.length === 0 ? (
+				<div className="text-center py-12 border-2 border-dashed border-muted-foreground/25 rounded-lg space-y-6">
+					<p className="text-muted-foreground">
+						No datasets available. Please create a dataset first.
+					</p>
 				</div>
 			) : (
 				<RadioCardGroup

--- a/src/app/dashboard/training/page.tsx
+++ b/src/app/dashboard/training/page.tsx
@@ -1,55 +1,23 @@
 "use client";
 
-import { jobsAtom, jobsLoadingAtom } from "@/atoms";
 import TrainingJobCard from "@/components/training-job-card";
 import { Button } from "@/components/ui/button";
-import { useAtom } from "jotai";
-import { Loader2, PlusIcon, RefreshCw } from "lucide-react";
+import { useTrainingJobs } from "@/hooks/useTrainingJobs";
+import { Loader2, PlusIcon } from "lucide-react";
 import Link from "next/link";
-import { useEffect } from "react";
 
 export default function TrainingJobsPage() {
-	const [jobs, setJobs] = useAtom(jobsAtom);
-	const [loading, setLoading] = useAtom(jobsLoadingAtom);
-
-	useEffect(() => {
-		fetchJobs();
-	}, []);
-
-	async function fetchJobs() {
-		setLoading(true);
-		try {
-			const res = await fetch("/api/jobs");
-			const data = await res.json();
-			setJobs(data.jobs || []);
-		} catch (err: unknown) {
-			setJobs([]);
-		} finally {
-			setLoading(false);
-		}
-	}
+	const { jobs, loading, error } = useTrainingJobs();
 
 	return (
 		<div>
 			<div className="flex items-center justify-between mb-6">
 				<h1 className="text-2xl font-bold">Training Jobs</h1>
-				<div className="flex gap-2">
-					<Button
-						variant="ghost"
-						size="icon"
-						onClick={() => fetchJobs()}
-						disabled={loading}
-						aria-label="Refresh jobs"
-					>
-						<RefreshCw className={loading ? "animate-spin" : ""} />
+				<Link href="/dashboard/training/new/model">
+					<Button variant="outline">
+						<PlusIcon className="w-4 h-4 mr-2" /> New Training Job
 					</Button>
-					<Link href="/dashboard/training/new/model">
-						<Button variant="outline">
-							<PlusIcon className="w-4 h-4 mr-2" /> New Training
-							Job
-						</Button>
-					</Link>
-				</div>
+				</Link>
 			</div>
 			{loading ? (
 				<div className="flex items-center justify-center py-12">
@@ -58,11 +26,22 @@ export default function TrainingJobsPage() {
 						<p className="text-muted-foreground">Loading jobs...</p>
 					</div>
 				</div>
-			) : (
+			) : error ? (
+				<div className="text-center py-12 border-2 border-dashed border-muted-foreground/25 rounded-lg space-y-6">
+					<p className="text-muted-foreground">{error}</p>
+				</div>
+			) : jobs.length > 0 ? (
 				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
 					{jobs.map(job => (
 						<TrainingJobCard key={job.job_id} job={job} />
 					))}
+				</div>
+			) : (
+				<div className="text-center py-12 border-2 border-dashed border-muted-foreground/25 rounded-lg space-y-6">
+					<p className="text-muted-foreground">
+						No training jobs yet. Start a training job to see it
+						here.
+					</p>
 				</div>
 			)}
 		</div>

--- a/src/app/dashboard/training/page.tsx
+++ b/src/app/dashboard/training/page.tsx
@@ -1,23 +1,36 @@
 "use client";
 
 import TrainingJobCard from "@/components/training-job-card";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { useTrainingJobs } from "@/hooks/useTrainingJobs";
-import { Loader2, PlusIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Loader2, PlusIcon, RefreshCcw } from "lucide-react";
 import Link from "next/link";
 
 export default function TrainingJobsPage() {
-	const { jobs, loading, error } = useTrainingJobs();
+	const { jobs, loading, error, refresh } = useTrainingJobs();
 
 	return (
 		<div>
 			<div className="flex items-center justify-between mb-6">
 				<h1 className="text-2xl font-bold">Training Jobs</h1>
-				<Link href="/dashboard/training/new/model">
-					<Button variant="outline">
-						<PlusIcon className="w-4 h-4 mr-2" /> New Training Job
+				<div className="flex items-center gap-2">
+					<Button
+						variant="outline"
+						onClick={() => refresh()}
+						disabled={loading}
+						className="cursor-pointer"
+					>
+						<RefreshCcw className={cn(loading && "animate-spin")} />
+						Refresh
 					</Button>
-				</Link>
+					<Link
+						href="/dashboard/training/new/model"
+						className={cn(buttonVariants({ variant: "outline" }))}
+					>
+						<PlusIcon /> New Training Job
+					</Link>
+				</div>
 			</div>
 			{loading ? (
 				<div className="flex items-center justify-center py-12">

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -202,6 +202,7 @@ export const jobsAtom = atom<TrainingJobsState>({
 	jobs: [],
 	loading: true,
 	error: null,
+	hasFetched: false,
 });
 
 /* ********** Job Cache Atom ********** */

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -1,25 +1,11 @@
 import { atom } from "jotai";
-import type { FieldMappings, UserFieldMapping } from "./types/dataset";
+import type {
+	DatasetsState,
+	FieldMappings,
+	UserFieldMapping,
+} from "./types/dataset";
 
 /* ********** Datasets Atoms ********** */
-export type Dataset = {
-	datasetName: string;
-	datasetId: string;
-	processed_dataset_id: string;
-	datasetSource: "huggingface" | "local";
-	datasetSubset: string;
-	numExamples: number;
-	createdAt: string;
-	splits: string[];
-	modality: "text" | "vision";
-};
-
-type DatasetsState = {
-	datasets: Dataset[];
-	loading: boolean;
-	error: string | null;
-};
-
 export const datasetsAtom = atom<DatasetsState>({
 	datasets: [],
 	loading: true,

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -1,3 +1,4 @@
+import type { TrainingJob, TrainingJobsState } from "@/types/training";
 import { atom } from "jotai";
 import type {
 	DatasetsState,
@@ -196,9 +197,11 @@ export const trainingJobNameAtom = atom<string>("");
 /* ********** Training Job Creation Atoms ********** */
 
 /* ********** Training Jobs Atoms ********** */
-import type { TrainingJob } from "@/types/training";
-export const jobsAtom = atom<TrainingJob[]>([]);
-export const jobsLoadingAtom = atom<boolean>(false);
+export const jobsAtom = atom<TrainingJobsState>({
+	jobs: [],
+	loading: true,
+	error: null,
+});
 
 /* ********** Job Cache Atom ********** */
 export const jobCacheAtom = atom<Record<string, TrainingJob>>({});

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -11,6 +11,7 @@ export const datasetsAtom = atom<DatasetsState>({
 	datasets: [],
 	loading: true,
 	error: null,
+	hasFetched: false,
 });
 /* ********** Datasets Atoms ********** */
 

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -13,8 +13,18 @@ export type Dataset = {
 	splits: string[];
 	modality: "text" | "vision";
 };
-export const datasetsAtom = atom<Dataset[]>([]);
-export const datasetsLoadingAtom = atom<boolean>(false);
+
+type DatasetsState = {
+	datasets: Dataset[];
+	loading: boolean;
+	error: string | null;
+};
+
+export const datasetsAtom = atom<DatasetsState>({
+	datasets: [],
+	loading: true,
+	error: null,
+});
 /* ********** Datasets Atoms ********** */
 
 /* ********** Dataset Selection Atoms ********** */

--- a/src/components/dashboard-nav.tsx
+++ b/src/components/dashboard-nav.tsx
@@ -9,6 +9,7 @@ import {
 	BreadcrumbList,
 	BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
+import Link from "next/link";
 import { Fragment } from "react";
 import { Separator } from "./ui/separator";
 import { SidebarTrigger } from "./ui/sidebar";
@@ -33,8 +34,8 @@ const DashboardNav = () => {
 							return (
 								<Fragment key={segment}>
 									<BreadcrumbItem>
-										<BreadcrumbLink href={path}>
-											{segment}
+										<BreadcrumbLink asChild>
+											<Link href={path}>{segment}</Link>
 										</BreadcrumbLink>
 									</BreadcrumbItem>
 									{index < filteredSegments.length - 1 && (

--- a/src/hooks/useDatasets.ts
+++ b/src/hooks/useDatasets.ts
@@ -1,75 +1,79 @@
 import { datasetsAtom } from "@/atoms";
-import { atom, useAtom } from "jotai";
-import { useEffect, useRef } from "react";
+import { useAtom } from "jotai";
+import { useCallback, useEffect, useRef } from "react";
 
 export function useDatasets() {
 	const [state, setState] = useAtom(datasetsAtom);
 	const isFetching = useRef(false);
+	const hasFetched = useRef(false);
+
+	const fetchDatasets = useCallback(async () => {
+		if (isFetching.current) return; // Prevent concurrent calls
+
+		try {
+			isFetching.current = true;
+			setState({ datasets: [], loading: true, error: null });
+
+			const res = await fetch("/api/datasets");
+			if (!res.ok) throw new Error("Failed to fetch datasets.");
+
+			const data = await res.json();
+
+			const formattedData = data.datasets.map(
+				(dataset: {
+					dataset_name: string;
+					dataset_id: string;
+					processed_dataset_id: string;
+					dataset_source: "upload" | "huggingface";
+					dataset_subset: string;
+					num_examples: number;
+					created_at: string;
+					splits: string[];
+					modality: "text" | "vision";
+				}) => ({
+					datasetName: dataset.dataset_name,
+					datasetId: dataset.dataset_id,
+					processed_dataset_id: dataset.processed_dataset_id,
+					datasetSource:
+						dataset.dataset_source === "upload"
+							? "local"
+							: "huggingface",
+					datasetSubset: dataset.dataset_subset,
+					numExamples: dataset.num_examples,
+					createdAt: dataset.created_at,
+					splits: dataset.splits,
+					modality: dataset.modality,
+				}),
+			);
+
+			setState({
+				datasets: formattedData,
+				loading: false,
+				error: null,
+			});
+		} catch (error) {
+			setState({
+				datasets: [],
+				loading: false,
+				error: error instanceof Error ? error.message : "Unknown error",
+			});
+		} finally {
+			isFetching.current = false;
+		}
+	}, [setState]);
 
 	useEffect(() => {
+		console.log("useEffect datasets");
+		// Only fetch once if we haven't fetched before and no data exists
 		if (
+			!hasFetched.current &&
 			state.datasets.length === 0 &&
-			!state.error &&
-			!isFetching.current
+			!state.error
 		) {
-			isFetching.current = true;
-			const fetchDatasets = async () => {
-				try {
-					setState({ datasets: [], loading: true, error: null });
-
-					const res = await fetch("/api/datasets");
-					if (!res.ok) throw new Error("Failed to fetch datasets.");
-
-					const data = await res.json();
-
-					const formattedData = data.datasets.map(
-						(dataset: {
-							dataset_name: string;
-							dataset_id: string;
-							processed_dataset_id: string;
-							dataset_source: "upload" | "huggingface";
-							dataset_subset: string;
-							num_examples: number;
-							created_at: string;
-							splits: string[];
-							modality: "text" | "vision";
-						}) => ({
-							datasetName: dataset.dataset_name,
-							datasetId: dataset.dataset_id,
-							processed_dataset_id: dataset.processed_dataset_id,
-							datasetSource:
-								dataset.dataset_source === "upload"
-									? "local"
-									: "huggingface",
-							datasetSubset: dataset.dataset_subset,
-							numExamples: dataset.num_examples,
-							createdAt: dataset.created_at,
-							splits: dataset.splits,
-							modality: dataset.modality,
-						}),
-					);
-					setState({
-						datasets: formattedData,
-						loading: false,
-						error: null,
-					});
-				} catch (error) {
-					setState({
-						datasets: [],
-						loading: false,
-						error:
-							error instanceof Error
-								? error.message
-								: "Unknown error",
-					});
-				} finally {
-					isFetching.current = false;
-				}
-			};
-
+			hasFetched.current = true;
 			fetchDatasets();
 		}
-	}, [state, setState]);
+	}, [state.datasets.length, state.error, fetchDatasets]);
 
-	return state;
+	return { ...state, refresh: fetchDatasets };
 }

--- a/src/hooks/useTrainingJobs.ts
+++ b/src/hooks/useTrainingJobs.ts
@@ -1,0 +1,45 @@
+import { jobsAtom } from "@/atoms";
+import { useAtom } from "jotai";
+import { useEffect, useRef } from "react";
+
+export function useTrainingJobs() {
+	const [state, setState] = useAtom(jobsAtom);
+	const isFetching = useRef(false);
+
+	useEffect(() => {
+		if (state.jobs.length === 0 && !state.error && !isFetching.current) {
+			isFetching.current = true;
+			const fetchTrainingJobs = async () => {
+				try {
+					setState({ jobs: [], loading: true, error: null });
+
+					const res = await fetch("/api/jobs");
+					if (!res.ok)
+						throw new Error("Failed to fetch training jobs.");
+
+					const data = await res.json();
+					setState({
+						jobs: data.jobs,
+						loading: false,
+						error: null,
+					});
+				} catch (error) {
+					setState({
+						jobs: [],
+						loading: false,
+						error:
+							error instanceof Error
+								? error.message
+								: "Unknown error",
+					});
+				} finally {
+					isFetching.current = false;
+				}
+			};
+
+			fetchTrainingJobs();
+		}
+	}, [state, setState]);
+
+	return state;
+}

--- a/src/hooks/useTrainingJobs.ts
+++ b/src/hooks/useTrainingJobs.ts
@@ -1,45 +1,47 @@
 import { jobsAtom } from "@/atoms";
 import { useAtom } from "jotai";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 export function useTrainingJobs() {
 	const [state, setState] = useAtom(jobsAtom);
 	const isFetching = useRef(false);
+	const hasFetched = useRef(false);
+
+	const fetchTrainingJobs = useCallback(async () => {
+		if (isFetching.current) return; // Prevent concurrent calls
+
+		try {
+			isFetching.current = true;
+			setState({ jobs: [], loading: true, error: null });
+
+			const res = await fetch("/api/jobs");
+			if (!res.ok) throw new Error("Failed to fetch training jobs.");
+
+			const data = await res.json();
+			setState({
+				jobs: data.jobs,
+				loading: false,
+				error: null,
+			});
+		} catch (error) {
+			setState({
+				jobs: [],
+				loading: false,
+				error: error instanceof Error ? error.message : "Unknown error",
+			});
+		} finally {
+			isFetching.current = false;
+		}
+	}, [setState]);
 
 	useEffect(() => {
-		if (state.jobs.length === 0 && !state.error && !isFetching.current) {
-			isFetching.current = true;
-			const fetchTrainingJobs = async () => {
-				try {
-					setState({ jobs: [], loading: true, error: null });
-
-					const res = await fetch("/api/jobs");
-					if (!res.ok)
-						throw new Error("Failed to fetch training jobs.");
-
-					const data = await res.json();
-					setState({
-						jobs: data.jobs,
-						loading: false,
-						error: null,
-					});
-				} catch (error) {
-					setState({
-						jobs: [],
-						loading: false,
-						error:
-							error instanceof Error
-								? error.message
-								: "Unknown error",
-					});
-				} finally {
-					isFetching.current = false;
-				}
-			};
-
+		console.log("useEffect training jobs");
+		// Only fetch once if we haven't fetched before and no data exists
+		if (!hasFetched.current && state.jobs.length === 0 && !state.error) {
+			hasFetched.current = true;
 			fetchTrainingJobs();
 		}
-	}, [state, setState]);
+	}, [state.jobs.length, state.error, fetchTrainingJobs]);
 
-	return state;
+	return { ...state, refresh: fetchTrainingJobs };
 }

--- a/src/hooks/useTrainingJobs.ts
+++ b/src/hooks/useTrainingJobs.ts
@@ -5,14 +5,18 @@ import { useCallback, useEffect, useRef } from "react";
 export function useTrainingJobs() {
 	const [state, setState] = useAtom(jobsAtom);
 	const isFetching = useRef(false);
-	const hasFetched = useRef(false);
 
 	const fetchTrainingJobs = useCallback(async () => {
 		if (isFetching.current) return; // Prevent concurrent calls
 
 		try {
 			isFetching.current = true;
-			setState({ jobs: [], loading: true, error: null });
+			setState({
+				jobs: [],
+				loading: true,
+				error: null,
+				hasFetched: true,
+			});
 
 			const res = await fetch("/api/jobs");
 			if (!res.ok) throw new Error("Failed to fetch training jobs.");
@@ -22,12 +26,14 @@ export function useTrainingJobs() {
 				jobs: data.jobs,
 				loading: false,
 				error: null,
+				hasFetched: true,
 			});
 		} catch (error) {
 			setState({
 				jobs: [],
 				loading: false,
 				error: error instanceof Error ? error.message : "Unknown error",
+				hasFetched: true,
 			});
 		} finally {
 			isFetching.current = false;
@@ -35,13 +41,11 @@ export function useTrainingJobs() {
 	}, [setState]);
 
 	useEffect(() => {
-		console.log("useEffect training jobs");
-		// Only fetch once if we haven't fetched before and no data exists
-		if (!hasFetched.current && state.jobs.length === 0 && !state.error) {
-			hasFetched.current = true;
+		// Only fetch once if we haven't fetched before
+		if (!state.hasFetched) {
 			fetchTrainingJobs();
 		}
-	}, [state.jobs.length, state.error, fetchTrainingJobs]);
+	}, [state.hasFetched, fetchTrainingJobs]);
 
 	return { ...state, refresh: fetchTrainingJobs };
 }

--- a/src/types/dataset.ts
+++ b/src/types/dataset.ts
@@ -15,6 +15,7 @@ export type DatasetsState = {
 	datasets: Dataset[];
 	loading: boolean;
 	error: string | null;
+	hasFetched: boolean;
 };
 
 export interface TextContentPart {

--- a/src/types/dataset.ts
+++ b/src/types/dataset.ts
@@ -1,3 +1,22 @@
+// Dataset Types
+export type Dataset = {
+	datasetName: string;
+	datasetId: string;
+	processed_dataset_id: string;
+	datasetSource: "huggingface" | "local";
+	datasetSubset: string;
+	numExamples: number;
+	createdAt: string;
+	splits: string[];
+	modality: "text" | "vision";
+};
+
+export type DatasetsState = {
+	datasets: Dataset[];
+	loading: boolean;
+	error: string | null;
+};
+
 export interface TextContentPart {
 	type: "text";
 	text: string;

--- a/src/types/training.ts
+++ b/src/types/training.ts
@@ -24,6 +24,7 @@ export type TrainingJobsState = {
 	jobs: TrainingJob[];
 	loading: boolean;
 	error: string | null;
+	hasFetched: boolean;
 };
 
 export interface BatchInferenceResult {

--- a/src/types/training.ts
+++ b/src/types/training.ts
@@ -20,6 +20,12 @@ export interface TrainingJob {
 	metrics?: EvaluationMetrics;
 }
 
+export type TrainingJobsState = {
+	jobs: TrainingJob[];
+	loading: boolean;
+	error: string | null;
+};
+
 export interface BatchInferenceResult {
 	results: string[];
 }


### PR DESCRIPTION
Fixes #7 

This PR implements `useDatasets` and `useTrainingJobs` hooks and utilizes them wherever all datasets or all jobs are being fetched.

With this PR, whenever a user visits a page that needs some resource (say `datasets` in this case), the app will check if the `datasets` already exists in the memory or not. If not, then it fetches the `datasets` and returns that; otherwise, if it does exist, then it returns that without fetching it again.

Same goes for the `jobs` resource.